### PR TITLE
Add OpenSSL protocol plugin

### DIFF
--- a/plugins/PluginOpenSSLProtocolSupport.py
+++ b/plugins/PluginOpenSSLProtocolSupport.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#-------------------------------------------------------------------------------
+# Name:         PluginOpenSSLProtocolSupport.py
+# Purpose:      Tests the server for supported SSL / TLS versions.
+#
+# Author:       bcyrill
+#
+# Copyright:    2014 SSLyze developers
+#
+#   SSLyze is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   SSLyze is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with SSLyze.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+from xml.etree.ElementTree import Element
+
+from plugins import PluginBase
+from utils.SSLyzeSSLConnection import create_sslyze_connection, SSLHandshakeRejected
+from nassl import SSLV2, SSLV3, TLSV1, TLSV1_1, TLSV1_2
+
+
+class PluginOpenSSLProtocolSupport(PluginBase.PluginBase):
+
+    interface = PluginBase.PluginInterface(title="PluginOpenSSLProtocolSupport", description="")
+    interface.add_command(
+        command="protocols",
+        help="Checks the support for the available SSL and TLS protocols.",
+        dest=None)
+
+
+    def process_task(self, target, command, args):
+        
+        OUT_FORMAT = '      {0:<35}{1}'.format
+        
+        sslVersionDict = [('SSLv2', SSLV2), 
+                        ('SSLv3', SSLV3),
+                        ('TLSv1.0', TLSV1),
+                        ('TLSv1.1', TLSV1_1),
+                        ('TLSv1.2', TLSV1_2)]
+        
+        cmdTitle = 'Protocol Version'
+        txtOutput = [self.PLUGIN_TITLE_FORMAT(cmdTitle)]
+        xmlOutput = Element(command, title=cmdTitle)
+        
+        for (sslVersionName, sslVersion) in sslVersionDict:
+            xmlNode = None
+            
+            sslConn = create_sslyze_connection(target, self._shared_settings, sslVersion)
+            sslConn.set_cipher_list('ALL:COMPLEMENTOFALL')
+            
+            try: # Perform the SSL handshake
+                sslConn.connect()
+                isSupported = 'Supported'
+                xmlNode = Element(sslVersionName)
+
+            except SSLHandshakeRejected as e:
+                isSupported = 'Not Supported - ' + str(e)
+
+            except:
+                raise
+            
+            finally:
+                sslConn.close()
+                txtOutput.append(OUT_FORMAT(sslVersionName, isSupported))
+                if xmlNode is not None:
+                    xmlOutput.append(xmlNode)
+        
+        return PluginBase.PluginResult(txtOutput, xmlOutput)
+

--- a/plugins/PluginOpenSSLProtocolSupport.py
+++ b/plugins/PluginOpenSSLProtocolSupport.py
@@ -36,7 +36,7 @@ class PluginOpenSSLProtocolSupport(PluginBase.PluginBase):
         help="Checks the support for the available SSL and TLS protocols.")
     interface.add_option(
             option="fallback",
-            help="Check the support for the TLS_FALLBACK_SCSV cipher suite")
+            help="Check the support for the TLS_FALLBACK_SCSV cipher suite.")
 
 
     def process_task(self, target, command, args):
@@ -61,7 +61,7 @@ class PluginOpenSSLProtocolSupport(PluginBase.PluginBase):
             sslConn = create_sslyze_connection(target, self._shared_settings, sslVersion)
             sslConn.set_cipher_list('ALL:COMPLEMENTOFALL')
             if self._shared_settings['fallback']:
-                sslConn.set_mode(SSL_MODE_SEND_FALLBACK_SCSV
+                sslConn.set_mode(SSL_MODE_SEND_FALLBACK_SCSV)
             
             try: # Perform the SSL handshake
                 sslConn.connect()

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -106,7 +106,7 @@ class PluginsFinder:
         AVAILABLE_PLUGIN_NAMES = ['plugins.PluginCompression', 'plugins.PluginCertInfo', 'plugins.PluginHeartbleed',
                                   'plugins.PluginHSTS', 'plugins.PluginOpenSSLCipherSuites',
                                   'plugins.PluginSessionRenegotiation', 'plugins.PluginSessionResumption',
-                                  'plugins.PluginChromeSha1Deprecation']
+                                  'plugins.PluginChromeSha1Deprecation', 'plugins.PluginOpenSSLProtocolSupport']
 
         # This it to ensure py2exe can find the plugins
         import plugins.PluginCompression
@@ -117,6 +117,7 @@ class PluginsFinder:
         import plugins.PluginSessionRenegotiation
         import plugins.PluginSessionResumption
         import plugins.PluginChromeSha1Deprecation
+        import plugins.PluginOpenSSLProtocolSupport
 
         for plugin_name in AVAILABLE_PLUGIN_NAMES:
             imported_module = importlib.import_module(plugin_name)

--- a/utils/SSLyzeSSLConnection.py
+++ b/utils/SSLyzeSSLConnection.py
@@ -175,7 +175,8 @@ class SSLConnection(DebugSslClient):
          'reset by peer' : 'Received RST'}
 
     HANDSHAKE_REJECTED_SSL_ERRORS = \
-        {'sslv3 alert handshake failure' : 'Alert handshake failure',
+        {'tlsv1 alert inappropriate fallback' : 'Alert inappropriate fallback',
+         'sslv3 alert handshake failure' : 'Alert handshake failure',
          'no ciphers available' : 'No ciphers available',
          'excessive message size' : 'Excessive message size',
          'bad mac decode' : 'Bad mac decode',


### PR DESCRIPTION
Added new plugin which can be used to quickly test the supported SSL / TLS protocols.

```
$ sslyze.py --protocols www.google.com
   * Protocol Version:
       SSLv2                              Not Supported - TLS / Unexpected EOF
       SSLv3                              Supported
       TLSv1.0                            Supported
       TLSv1.1                            Supported
       TLSv1.2                            Supported
```
The plugin also supports usage of the newly introduced TLS_FALLBACK_SCSV service cipher suite value (e.g. to ensure it is properly supported on the server).

```
$ sslyze.py --protocols --fallback www.google.com
   * Protocol Version (using TLS_FALLBACK_SCSV):
       SSLv2                              Not Supported - TLS / Unexpected EOF
       SSLv3                              Not Supported - TLS / Alert inappropriate fallback
       TLSv1.0                            Not Supported - TLS / Alert inappropriate fallback
       TLSv1.1                            Not Supported - TLS / Alert inappropriate fallback
       TLSv1.2                            Supported
```

Requires updated nassl with https://github.com/nabla-c0d3/nassl/pull/19