### PR TITLE
PluginCertInfo can generate bad XML, causing crash

### DIFF
--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -387,6 +387,8 @@ class PluginCertInfo(PluginBase.PluginBase):
 def _create_xml_node(key, value=''):
     key = key.replace(' ', '').strip() # Remove spaces
     key = key.replace('/', '').strip() # Remove slashes (S/MIME Capabilities)
+    key = key.replace('<' , '_')
+    key = key.replace('>' , '_')
 
     # Things that would generate invalid XML
     if key[0].isdigit(): # Tags cannot start with a digit


### PR DESCRIPTION
In some circumstances, `_create_xml_node` in `PluginCertInfo.py` gets called with a key like "`<Foo>`".  When the resulting xml tree is serialized and re-parsed with minidom in `sslyze.py`, the application crashes due to the invalid XML (`<<Foo> />`).

One example is the cert below, where the subjectAltName value is an empty string, resulting in a node named `<ParseError>`.  I've also seen `<Empty>` in the same field for another cert.

This commit is a quick tweak to prevent the application from crashing; I'm not sure if there's a better way to handle bogus values in certs in general, either within sslyze or down in nassl.

```
-----BEGIN CERTIFICATE-----
MIICrDCCAZSgAwIBAgIJANyuko6C2HhwMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNV
BAMMBGRlbW8wHhcNMTQxMjExMjAwNTQ2WhcNMjQxMjA4MjAwNTQ2WjAPMQ0wCwYD
VQQDDARkZW1vMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA11ooS5OM
rUo1Viak3hhE9eIR1tPuFanO2+jowLAImytPiWxuBlVFINW+EX7TNEZJcrf52MtA
Opy19unT7c0dAjVh7pIxjCgMvH0yecVdt3DHUg3ItyMBJWTI1t+t2+IQMaHCLOsS
Ky29lgk8pegYR0A2O0D6SayjI0lXS2GW78BAnJJIhmluSrBLKHLrwNQZ2hWTrM9H
VgRWDI49r9nI7sM7aXUdabTKQmJlsgUbigXEB2Z/myM+RN+zBTfbnSa9V5Asn+gR
5YGQ1jIEOuuIJzd/+hHyO4xUPkki0n3ECMLyFOo6bMi0uSKfxsDIckzloF2TRuk/
DFzIDQ5mz/MEdQIDAQABowswCTAHBgNVHREEADANBgkqhkiG9w0BAQsFAAOCAQEA
OAgMKke3Ha6BL47eEzsGsnD1GC1Bjr6wC7tlTWfn1ykadcn9WnXIUOTAERFPtSnB
oKvoKBWhX6yw1CKLdg4S4bFZSDzlKPNnmEnGqlKKQL1I3/TNCIZ8gxAtOi1KOjiW
3JQCP0tbVMRTClCsRlP22/8esvO0lYAeamOpOjgSWiNmpToVKh7+Pcj2MpIcUJMe
vSk+NtL9Mcgw6sM0Fdm/Vh3Xr2LaAk+oufA5eBC9nlq/C+Gm3K6Yiy2BRVfBvxe+
wC54Fu3fdcD2ITymImBgYq2Qje9Ct3WZDGu/zYc6vxCgboHJFIZfE1GRFLmWQNhR
Y6B3d9EgNuv4ve87itHIMQ==
-----END CERTIFICATE-----
```
