### PR TITLE
Use a PyPA/semver supported version number

### DIFF
--- a/sslyze.py
+++ b/sslyze.py
@@ -39,7 +39,7 @@ except ImportError as e:
     sys.exit()
 
 
-PROJECT_VERSION = 'SSLyze v0.11 beta'
+PROJECT_VERSION = '0.11.0'
 PROJECT_URL = "https://github.com/nabla-c0d3/sslyze"
 PROJECT_EMAIL = 'nabla.c0d3@gmail.com'
 PROJECT_DESC = 'Fast and full-featured SSL scanner'


### PR DESCRIPTION
Currently https://pypi.python.org/pypi/SSLyze is broken because the version number is incompatible with PIP.

Once we've started getting this working, people can simply do:

"pip install sslyze" and they will download a bult wheel for their platform.

I can add you as a maintainer for the registered package if you like.
