### PR TITLE
added xmpp s2s starttls

### DIFF
--- a/test/xmpp_test.txt
+++ b/test/xmpp_test.txt
@@ -1,1 +1,2 @@
 # python sslyze.py --tlsv1 --sslv2 --sslv3 --tlsv1_1 --tlsv1_2 --hide_rejected_ciphers --certinfo=basic --reneg --resum --starttls=xmpp --xmpp_to=gmail.com talk.google.com
+# python sslyze.py --tlsv1 --sslv2 --sslv3 --tlsv1_1 --tlsv1_2 --hide_rejected_ciphers --certinfo=basic --reneg --resum --starttls=xmpp_server jabber.org

--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -46,7 +46,7 @@ class CommandLineParser():
     SSLYZE_USAGE = 'usage: %prog [options] target1.com target2.com:443 etc...'
 
     # StartTLS options
-    START_TLS_PROTS = ['smtp', 'xmpp', 'pop3', 'ftp', 'imap', 'ldap', 'rdp', 'postgres', 'auto']
+    START_TLS_PROTS = ['smtp', 'xmpp', 'xmpp_server', 'pop3', 'ftp', 'imap', 'ldap', 'rdp', 'postgres', 'auto']
     START_TLS_USAGE = 'STARTTLS should be one of: ' + str(START_TLS_PROTS) +  \
         '. The \'auto\' option will cause SSLyze to deduce the protocol' + \
         ' (ftp, imap, etc.) from the supplied port number, for each target servers.'

--- a/utils/SSLyzeSSLConnection.py
+++ b/utils/SSLyzeSSLConnection.py
@@ -49,12 +49,14 @@ def create_sslyze_connection(target, shared_settings, sslVersion=None, sslVerify
     timeout = shared_settings['timeout']
     startTls = shared_settings['starttls']
 
+<<<<<<< HEAD
     STARTTLS_DISPATCH = { 'smtp' :  SMTPConnection,
                           587 :     SMTPConnection,
                           25 :      SMTPConnection,
                           'xmpp':   XMPPConnection,
                           5222 :    XMPPConnection,
-                          5269 :    XMPPConnection,
+                          'xmpp_server': XMPPServerConnection,
+                          5269 :         XMPPServerConnection,
                           'pop3' :  POP3Connection,
                           109 :     POP3Connection,
                           110 :     POP3Connection,
@@ -461,6 +463,11 @@ class XMPPConnection(SSLConnection):
         if 'proceed'  not in xmpp_resp:
             raise StartTLSError(self.ERR_XMPP_NO_STARTTLS)
 
+
+class XMPPServerConnection(XMPPConnection):
+    XMPP_OPEN_STREAM = ("<stream:stream xmlns='jabber:server' xmlns:stream='"
+        "http://etherx.jabber.org/streams' xmlns:tls='http://www.ietf.org/rfc/"
+        "rfc2595.txt' to='{0}' xml:lang='en' version='1.0'>" )
 
 
 class LDAPConnection(SSLConnection):

--- a/utils/SSLyzeSSLConnection.py
+++ b/utils/SSLyzeSSLConnection.py
@@ -87,7 +87,7 @@ def create_sslyze_connection(target, shared_settings, sslVersion=None, sslVerify
                 connectionClass = SSLConnection
 
         # XMPP configuration
-        if connectionClass == XMPPConnection:
+        if connectionClass in (XMPPConnection, XMPPServerConnection):
             sslConn = connectionClass(target, sslVerifyLocations, timeout,
                                       shared_settings['nb_retries'],
                                       shared_settings['xmpp_to'])

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -107,14 +107,15 @@ class ServersConnectivityTester(object):
 
     MAX_THREADS = 50
 
-    DEFAULT_PORTS = {'smtp'     : 25,
-                     'xmpp'     : 5222,
-                     'ftp'      : 21,
-                     'pop3'     : 110,
-                     'ldap'     : 389,
-                     'imap'     : 143,
-                     'rdp'      : 3389,
-                     'default'  : 443}
+    DEFAULT_PORTS = {'smtp'       : 25,
+                     'xmpp'       : 5222,
+                     'xmpp_server': 5269,
+                     'ftp'        : 21,
+                     'pop3'       : 110,
+                     'ldap'       : 389,
+                     'imap'       : 143,
+                     'rdp'        : 3389,
+                     'default'    : 443}
 
     ERR_TIMEOUT = 'Could not connect (timeout)'
     ERR_NAME_NOT_RESOLVED = 'Could not resolve hostname'


### PR DESCRIPTION
Server 2 server communication based on rfc6120 needs a jabber:server namespace instead of a jabber:client.