### PR TITLE
Added a new plugin to detect the use of TLS Server Name Indication (SNI)

### DIFF
--- a/plugins/PluginSNI.py
+++ b/plugins/PluginSNI.py
@@ -53,7 +53,7 @@ class PluginSNI(PluginBase.PluginBase):
         if sni_supported:
             txt_result.append(self.FIELD_FORMAT("YES - SNI is in use.", ""))
         else:
-            txt_result.append(self.FIELD_FORMAT("NO - SNI was not detected/activated. Could be a false-negative if this is the default SSL Virtual Host.", ""))
+            txt_result.append(self.FIELD_FORMAT("NO - SNI was not detected/activated. Could be a false-negative if the target host provides the same certificate for the default SSL Virtual Host.", ""))
 
         # XML output
         xml_sni_attr = {'has_SniSupport': str(sni_supported)}

--- a/plugins/PluginSNI.py
+++ b/plugins/PluginSNI.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+# Name:         PluginSNI.py
+# Purpose:      Checks if the server is using SNI
+#
+# Author:       Oscar Koeroo
+#
+# Copyright:    2015 SSLyze developers
+#
+#   SSLyze is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   SSLyze is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with SSLyze.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+from xml.etree.ElementTree import Element
+from utils.HTTPResponseParser import parse_http_response
+from utils.SSLyzeSSLConnection import create_sslyze_connection
+from plugins import PluginBase
+from urlparse import urlparse
+import Cookie
+
+
+class PluginSNI(PluginBase.PluginBase):
+
+    interface = PluginBase.PluginInterface(title="PluginSNI", description=(''))
+    interface.add_command(
+        command="snitest",
+        help="Checks support for Server Name Indication by trying "
+             "to connect with an without SNI enabled. Server Name "
+             "Indication (SNI) is an extension to TLS.",
+        dest=None)
+
+
+    def process_task(self, target, command, args):
+        if self._shared_settings['sni']:
+            raise Exception('Cannot use --snitest with --sni.')
+
+        sni_supported = self._get_sni_support(target)
+        if sni_supported:
+            sni_timeout = sni_supported
+            sni_supported = True
+
+        # Text output
+        cmd_title = 'SNI tester'
+        txt_result = [self.PLUGIN_TITLE_FORMAT(cmd_title)]
+        if sni_supported:
+            txt_result.append(self.FIELD_FORMAT("YES - SNI is in use.", ""))
+        else:
+            txt_result.append(self.FIELD_FORMAT("NO - SNI was not detected/activated. Could be a false-negative if this is the default SSL Virtual Host.", ""))
+
+        # XML output
+        xml_sni_attr = {'has_SniSupport': str(sni_supported)}
+        if sni_supported:
+            xml_sni_attr['sniHeaderValue'] = sni_timeout
+        xml_sni = Element('snitest', attrib = xml_sni_attr)
+
+        xml_result = Element('snitest', title = cmd_title)
+        xml_result.append(xml_sni)
+
+        return PluginBase.PluginResult(txt_result, xml_result)
+
+
+
+    def _get_sni_support(self, target):
+        (host, _, _, _) = target
+
+
+        # Without SNI
+        sslConn = create_sslyze_connection(target, self._shared_settings)
+
+        # Perform the SSL handshake
+        sslConn.connect()
+        x509Chain1 = sslConn.get_peer_cert_chain()
+        x509Cert1 = x509Chain1[0] # First cert is always the leaf cert
+        sslConn.close()
+
+
+        # Without SNI
+        sslConn = create_sslyze_connection(target, self._shared_settings)
+        if self._shared_settings['sni']:
+            sslConn.set_tlsext_host_name(shared_settings['sni'])
+        else:
+            sslConn.set_tlsext_host_name(host)
+
+
+        # Perform the SSL handshake
+        sslConn.connect()
+        x509Chain2 = sslConn.get_peer_cert_chain()
+        x509Cert2 = x509Chain2[0] # First cert is always the leaf cert
+        sslConn.close()
+
+
+        # Match fingerprints
+        if x509Cert1.get_SHA1_fingerprint() == x509Cert2.get_SHA1_fingerprint():
+           return False
+        else:
+           return True
+


### PR DESCRIPTION
It will compare the fingerprints of the EEC/leaf certificates of a chain. If there is a difference noticed based on toggling the SNI on or off, this will conclude if SNI was used or a different verdict.