### PR TITLE
Compatibility for systems which have python3 installed as default python

### DIFF
--- a/plugins/PluginBase.py
+++ b/plugins/PluginBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginBase.py
 # Purpose:      Main abstract plugin class. All the plugins are

--- a/plugins/PluginBase.py
+++ b/plugins/PluginBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginBase.py
 # Purpose:      Main abstract plugin class. All the plugins are

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginCertInfo.py
 # Purpose:      Verifies the target server's certificate validity against

--- a/plugins/PluginCertInfo.py
+++ b/plugins/PluginCertInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginCertInfo.py
 # Purpose:      Verifies the target server's certificate validity against

--- a/plugins/PluginChromeSha1Deprecation.py
+++ b/plugins/PluginChromeSha1Deprecation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginChromeSha1Deprecation.py
 # Purpose:      Determines if the certificate will be affected by Google 

--- a/plugins/PluginChromeSha1Deprecation.py
+++ b/plugins/PluginChromeSha1Deprecation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginChromeSha1Deprecation.py
 # Purpose:      Determines if the certificate will be affected by Google 

--- a/plugins/PluginCompression.py
+++ b/plugins/PluginCompression.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginCompression.py
 # Purpose:      Tests the server for Zlib compression support.

--- a/plugins/PluginCompression.py
+++ b/plugins/PluginCompression.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginCompression.py
 # Purpose:      Tests the server for Zlib compression support.

--- a/plugins/PluginHSTS.py
+++ b/plugins/PluginHSTS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
 # Name:         PluginHSTS.py

--- a/plugins/PluginHSTS.py
+++ b/plugins/PluginHSTS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #-------------------------------------------------------------------------------
 # Name:         PluginHSTS.py

--- a/plugins/PluginHeartbleed.py
+++ b/plugins/PluginHeartbleed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginHeartbleed.py
 # Purpose:      Tests the target server for CVE-2014-0160.

--- a/plugins/PluginHeartbleed.py
+++ b/plugins/PluginHeartbleed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginHeartbleed.py
 # Purpose:      Tests the target server for CVE-2014-0160.

--- a/plugins/PluginOpenSSLCipherSuites.py
+++ b/plugins/PluginOpenSSLCipherSuites.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginOpenSSLCipherSuites.py
 # Purpose:      Scans the target server for supported OpenSSL cipher suites.

--- a/plugins/PluginOpenSSLCipherSuites.py
+++ b/plugins/PluginOpenSSLCipherSuites.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginOpenSSLCipherSuites.py
 # Purpose:      Scans the target server for supported OpenSSL cipher suites.

--- a/plugins/PluginSessionRenegotiation.py
+++ b/plugins/PluginSessionRenegotiation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginSessionRenegotiation.py
 # Purpose:      Tests the target server for insecure renegotiation.

--- a/plugins/PluginSessionRenegotiation.py
+++ b/plugins/PluginSessionRenegotiation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginSessionRenegotiation.py
 # Purpose:      Tests the target server for insecure renegotiation.

--- a/plugins/PluginSessionResumption.py
+++ b/plugins/PluginSessionResumption.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         PluginSessionResumption.py
 # Purpose:      Analyzes the server's SSL session resumption capabilities.

--- a/plugins/PluginSessionResumption.py
+++ b/plugins/PluginSessionResumption.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         PluginSessionResumption.py
 # Purpose:      Analyzes the server's SSL session resumption capabilities.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         __init__.py
 # Purpose:      PluginsFinder class for the SSLyze plugins package.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         __init__.py
 # Purpose:      PluginsFinder class for the SSLyze plugins package.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 from sys import platform
 from sslyze import PROJECT_VERSION, PROJECT_URL, PROJECT_EMAIL, PROJECT_DESC
 from distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from sys import platform
 from sslyze import PROJECT_VERSION, PROJECT_URL, PROJECT_EMAIL, PROJECT_DESC
 from distutils.core import setup

--- a/setup_py2exe.py
+++ b/setup_py2exe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # C:\Python27_32\python.exe setup_py2exe.py py2exe
 from distutils.core import setup
 from glob import glob

--- a/setup_py2exe.py
+++ b/setup_py2exe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # C:\Python27_32\python.exe setup_py2exe.py py2exe
 from distutils.core import setup
 from glob import glob

--- a/sslyze.py
+++ b/sslyze.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         sslyze.py
 # Purpose:      Main module of SSLyze.

--- a/sslyze.py
+++ b/sslyze.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         sslyze.py
 # Purpose:      Main module of SSLyze.

--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         CommandLineParser.py
 # Purpose:      Command line parsing utilities for SSLyze.

--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         CommandLineParser.py
 # Purpose:      Command line parsing utilities for SSLyze.

--- a/utils/SSLyzeSSLConnection.py
+++ b/utils/SSLyzeSSLConnection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         SSLyzeSSLConnection.py
 # Purpose:      The SSL connection class that all SSLyze Plugins should be

--- a/utils/SSLyzeSSLConnection.py
+++ b/utils/SSLyzeSSLConnection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         SSLyzeSSLConnection.py
 # Purpose:      The SSL connection class that all SSLyze Plugins should be

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         ServersConnectivityTester.py
 # Purpose:      Initial checks to figure out which servers supplied by the

--- a/utils/ServersConnectivityTester.py
+++ b/utils/ServersConnectivityTester.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         ServersConnectivityTester.py
 # Purpose:      Initial checks to figure out which servers supplied by the

--- a/utils/ThreadPool.py
+++ b/utils/ThreadPool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-------------------------------------------------------------------------------
 # Name:         ThreadPool.py
 # Purpose:      Generic, simple thread pool used in some of the plugins.

--- a/utils/ThreadPool.py
+++ b/utils/ThreadPool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #-------------------------------------------------------------------------------
 # Name:         ThreadPool.py
 # Purpose:      Generic, simple thread pool used in some of the plugins.


### PR DESCRIPTION
This is done by simply changing the first line in *.py files to invoke:
```/usr/bin/env python2```

This most likely needs some testing on other systems before merging, but is working great for me on Arch Linux (using sslyze-git AUR package).