### PR TITLE
Allow user to specify ciphers to test

### DIFF
--- a/plugins/PluginOpenSSLCipherSuites.py
+++ b/plugins/PluginOpenSSLCipherSuites.py
@@ -204,13 +204,10 @@ class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
         return txtOutput
 
 
-#    @staticmethod
     def _generate_xml_output(self, result_dicts, command):
 
         xmlNodeList = []
         isProtocolSupported = False
-
-        xmlNode = Element('ssl_cipher_list')
 
         for (resultKey, resultDict) in result_dicts.items():
             xmlNode = Element(resultKey)

--- a/plugins/PluginOpenSSLCipherSuites.py
+++ b/plugins/PluginOpenSSLCipherSuites.py
@@ -32,6 +32,7 @@ from nassl.SslClient import SslClient
 
 class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
 
+    DEFAULT_CIPHERLIST = "ALL:COMPLEMENTOFALL"
 
     interface = PluginBase.PluginInterface(
         "PluginOpenSSLCipherSuites",
@@ -64,6 +65,13 @@ class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
         option='hide_rejected_ciphers',
         help="Option - Hides the (usually long) list of cipher suites that were"
         " rejected by the server(s).")
+    interface.add_option(
+        option='cipherlist',
+        help="Option - Test only these ciphers. Default: \"" + DEFAULT_CIPHERLIST +
+            "\" (This tests all ciphers). See "
+            "https://www.openssl.org/docs/apps/ciphers.html for the format of "
+            "the cipherlist string.",
+        dest='test_cipherlist')
 
 
     def process_task(self, target, command, args):
@@ -81,7 +89,15 @@ class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
 
         # Get the list of available cipher suites for the given ssl version
         sslClient = SslClient(sslVersion=sslVersion)
-        sslClient.set_cipher_list('ALL:COMPLEMENTOFALL')
+
+	if not self._shared_settings['test_cipherlist']:
+	    self._shared_settings['test_cipherlist'] = PluginOpenSSLCipherSuites.DEFAULT_CIPHERLIST
+        try:
+            sslClient.set_cipher_list(self._shared_settings['test_cipherlist'])
+        except Exception as e:
+	    raise Exception("PluginOpenSSLCipherSuites: Bad cipherlist. "
+                    "See https://www.openssl.org/docs/apps/ciphers.html for syntax.")
+
         cipher_list = sslClient.get_cipher_list()
 
         # Create a thread pool
@@ -146,6 +162,8 @@ class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
             #txtOutput.append('')
             #txtOutput.append(titleFormat('Rejected:  Hidden'))
 
+        txtOutput.append(titleFormat('Attempted Cipher List: ' + self._shared_settings['test_cipherlist']))
+
         for (resultKey, resultTitle) in dictTitles:
 
             # Sort the cipher suites by results
@@ -186,11 +204,13 @@ class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
         return txtOutput
 
 
-    @staticmethod
-    def _generate_xml_output(result_dicts, command):
+#    @staticmethod
+    def _generate_xml_output(self, result_dicts, command):
 
         xmlNodeList = []
         isProtocolSupported = False
+
+        xmlNode = Element('ssl_cipher_list')
 
         for (resultKey, resultDict) in result_dicts.items():
             xmlNode = Element(resultKey)
@@ -222,7 +242,7 @@ class PluginOpenSSLCipherSuites(PluginBase.PluginBase):
             xmlNodeList.append(xmlNode)
 
         # Create the final node and specify if the protocol was supported
-        xmlOutput = Element(command, title=command.upper() + ' Cipher Suites', isProtocolSupported=str(isProtocolSupported))
+        xmlOutput = Element(command, title=command.upper() + ' Cipher Suites', isProtocolSupported=str(isProtocolSupported), cipher_list=self._shared_settings['test_cipherlist'])
         for xmlNode in xmlNodeList:
             xmlOutput.append(xmlNode)
 


### PR DESCRIPTION
When using the OpenSSL cipher suites plugin, allow the user to specify a cipher list. This allows quicker, more targeted scans. For example, to ensure that a server is not using a list of specifically prohibited ciphers, such as export-grade ciphers.

Example:

#only test for export-grade cipher suites
sslyze.py target --sslv2 --cipherlist=EXP

This change modifies the default output of sslyze 3 ways:
1. Adds description of the cipherlist option in the help output
```
    --cipherlist=TEST_CIPHERLIST
                        Option - Test only these ciphers. Default:
                        "ALL:COMPLEMENTOFALL" (This tests all ciphers). See
                        https://www.openssl.org/docs/apps/ciphers.html for the
                        format of the cipherlist string.
```
2. Adds a line in the text output specifying the cipherlist used. For consistency's sake, the cipherlist is displayed whether or not the user specified a cipherlist.
```
SCAN RESULTS FOR LOCALHOST:443 - 127.0.0.1:443
 ---------------------------------------------------------------

  * SSLV3 Cipher Suites:
      Attempted Cipher List: ALL:COMPLEMENTOFALL
      Preferred:
```
3. Adds similar xml output. Again, for consistency's sake, the cipherlist is included whether or not the user specified a cipher list.
```
<?xml version="1.0" encoding="utf-8"?>
<document SSLyzeVersion="0.11.0" SSLyzeWeb="https://github.com/nabla-c0d3/sslyze" title="SSLyze Scan Results">
  <invalidTargets/>
  <results defaultTimeout="5" httpsTunnel="None" startTLS="None" totalScanTime="3.3044860363">
    <target host="localhost" ip="127.0.0.1" port="443">
      <sslv3 cipher_list="ALL:COMPLEMENTOFALL" isProtocolSupported="True" title="SSLV3 Cipher Suites">
        <errors/>
```

In order for _generate_xml_output to have access to the cipher list I converted it from a static method to an instance method. I found nowhere else that _generate_xml_output was called, so this change doesn't change the plugin's interface or anything. Seems pretty safe.