### PR TITLE
Bypass dns resolution with ip added to target hostname

### DIFF
--- a/utils/CommandLineParser.py
+++ b/utils/CommandLineParser.py
@@ -43,7 +43,7 @@ class CommandLineParser():
     REGULAR_CMD = ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2', 'reneg',
                    'resum', 'certinfo', 'http_get', 'hide_rejected_ciphers',
                    'compression', 'heartbleed']
-    SSLYZE_USAGE = 'usage: %prog [options] target1.com target2.com:443 etc...'
+    SSLYZE_USAGE = 'usage: %prog [options] target1.com target2.com:443 target3.com:443{ip} etc...'
 
     # StartTLS options
     START_TLS_PROTS = ['smtp', 'xmpp', 'xmpp_server', 'pop3', 'ftp', 'imap', 'ldap', 'rdp', 'postgres', 'auto']


### PR DESCRIPTION
Hello,

I'm using extensively SSLyze to validate production hostnames, but some of them are behind a load-balancer meaning that checking with SSLyze my.hostname will resolve to 1.2.3.4 or 1.2.5.4 for exemple. So I added a syntax to specify the ip with the target with format `hostname:port{ip}` and SSLyze will use the specified ip to connect to hostname.
It handles ipv4 and [ipv6] and brings no regression.

``` 
sslyze.py --certinfo=basic [2a00:1450:4006:803::200e] ipv6.google.com{[2a00:1450:4006:803::200e]}

 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   2a00:1450:4006:803::200e:443        => 2a00:1450:4006:803::200e:443
   ipv6.google.com:443                 => 2a00:1450:4006:803::200e:443

```