### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Then, the command line tool can be used to scan servers:
 
     python sslyze_cli.py --regular www.yahoo.com:443 www.google.com
 
-On Linux, the `python-devel` package needs to be installed first so that the nassl C extension can be compiled:
+On Linux, the `python-dev` package needs to be installed first so that the nassl C extension can be compiled:
 
-    sudo apt-get install python-devel
+    sudo apt-get install python-dev
 
 SSLyze has been tested on the following platforms: Windows 7 (32 and 64 bits), Debian 7 (32 and 64 bits), OS X El 
 Capitan.


### PR DESCRIPTION
Development packages in Debian usually ended with `-dev` instead of `devel`.