### PR TITLE
add sha1 signature verification if certificate chain order is incorrect

### DIFF
--- a/sslyze/plugins/certificate_info_plugin.py
+++ b/sslyze/plugins/certificate_info_plugin.py
@@ -306,6 +306,16 @@ class CertificateInfoScanResult(PluginScanResult):
                 if isinstance(cert.signature_hash_algorithm, hashes.SHA1):
                     self.has_sha1_in_certificate_chain = True
                     break
+        # Check as a fallback if the certificate is trusted but the certificate chain is incorrect
+        elif self.successful_trust_store and not self.is_certificate_chain_order_valid:
+            for cert in self.certificate_chain:
+                if isinstance(cert.signature_hash_algorithm, hashes.SHA1):
+                    # Get certificate name
+                    cert_name = CertificateUtils.get_printable_name(cert.subject).lower()
+                    # Avoid root certificate that can still be signed with SHA1
+                    if "root" not in cert_name:
+                        self.has_sha1_in_certificate_chain = True
+                        break
 
     def __getstate__(self):
         # This object needs to be pick-able as it gets sent through multiprocessing.Queues


### PR DESCRIPTION
Hello,

In the latest versions I noticed that the flag `Verified Chain contains SHA1` was only set if a valid certificate chain could be build from the received chain. 
For the purpose of maximum information given at once (contrary to an endless loop of die and retry), an auditor will appreciate to know that the certificate chain is incorrect order and contains SHA1, rather than first getting the sysadmin to fix the chain order, and then learning that he has to take another action to change incriminated certificate.