### PR TITLE
Remove duplicate `prime` attribute under `keyExchange`

### DIFF
--- a/xml_out.xsd
+++ b/xml_out.xsd
@@ -430,7 +430,6 @@
             <xs:attribute name="Prime"/>
             <xs:attribute name="Seed"/>
             <xs:attribute name="Type" use="required"/>
-            <xs:attribute name="prime"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>


### PR DESCRIPTION
`Prime` is already listed under `keyExchange`.