### PR TITLE
Update concurrent_scanner.py

### DIFF
--- a/sslyze/concurrent_scanner.py
+++ b/sslyze/concurrent_scanner.py
@@ -120,7 +120,7 @@ class ConcurrentScanner(object):
             else:
                 # We are already using the maximum number of processes
                 # Do not create a process and re-use a random existing hostname queue
-                self._hostname_queues_dict[hostname] = random.choice(self._hostname_queues_dict.values())
+                self._hostname_queues_dict[hostname] = random.choice(list(self._hostname_queues_dict.values()))
                 self._processes_dict[hostname] = []
 
         else:


### PR DESCRIPTION
In Py3.x doing `dict.values()` returns a `dict_values` instance which does not allow index lookup. Have to convert it to a `list`

```python
>>> a = {'a':1, 'b':2}
>>> a.values()
dict_values([1, 2])
>>> list(a.values())[0]
1
>>> a.values()[0]
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    a.values()[0]
TypeError: 'dict_values' object does not support indexing
>>> 
```