### PR TITLE
Update certificate_info_plugin.py

### DIFF
--- a/sslyze/plugins/certificate_info_plugin.py
+++ b/sslyze/plugins/certificate_info_plugin.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import optparse
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from ssl import CertificateError
 from xml.etree.ElementTree import Element


### PR DESCRIPTION
Remove timezone which does not exist in Python 2 and is not used by the plugin anyway.