### PR TITLE
Keep the OCSP response if the validation was successful and a response was returned.

### DIFF
--- a/sslyze/plugins/certificate_info_plugin.py
+++ b/sslyze/plugins/certificate_info_plugin.py
@@ -150,7 +150,12 @@ class CertificateInfoPlugin(plugin_base.Plugin):
 
         for (job, result) in thread_pool.get_result():
             (_, (_, trust_store)) = job
-            certificate_chain, validation_result, ocsp_response = result
+            certificate_chain, validation_result, _ocsp_response = result
+
+            # Keep the OCSP response if the validation was succesful and a response was returned
+            if _ocsp_response:
+                ocsp_response = _ocsp_response
+                
             # Store the returned verify string for each trust store
             path_validation_result_list.append(PathValidationResult(trust_store, validation_result))
 


### PR DESCRIPTION
In some cases a single request may fail to return an ocsp response. This will now retain any valid ocsp responses discovered. 