### PR TITLE
Fix two issues with JSON and XML output

### DIFF
--- a/sslyze/cli/json_output.py
+++ b/sslyze/cli/json_output.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, TextIO, Type, Set, Union, List
 from cryptography.hazmat.backends.openssl import x509
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import ObjectIdentifier
 from enum import Enum
 from sslyze import PROJECT_URL, __version__
 from sslyze.cli import CompletedServerScan
@@ -86,6 +87,10 @@ def _object_to_json_dict(obj: Any) -> Union[bool, int, float, str, Dict[str, Any
     if isinstance(obj, Enum):
         # Properly serialize Enums (such as OpenSslVersionEnum)
         result = obj.name
+
+    elif isinstance(obj, ObjectIdentifier):
+        # Use dotted string representation for OIDs
+        result = obj.dotted_string
 
     elif isinstance(obj, x509._Certificate):
         # Properly serialize certificates

--- a/sslyze/cli/output_hub.py
+++ b/sslyze/cli/output_hub.py
@@ -33,12 +33,14 @@ class OutputHub:
 
         # Configure the JSON output
         if args_command_list.json_file:
-            json_file_to = sys.stdout if args_command_list.json_file == '-' else open(args_command_list.json_file, 'wt')
+            json_file_to = sys.stdout if args_command_list.json_file == '-' else open(args_command_list.json_file, 'wt',
+                                                                                      encoding="utf-8")
             self._output_generator_list.append(JsonOutputGenerator(json_file_to))  # type: ignore
 
         # Configure the XML output
         if args_command_list.xml_file:
-            xml_file_to = sys.stdout if args_command_list.xml_file == '-' else open(args_command_list.xml_file, 'wt')
+            xml_file_to = sys.stdout if args_command_list.xml_file == '-' else open(args_command_list.xml_file, 'wt',
+                                                                                    encoding="utf-8")
             self._output_generator_list.append(XmlOutputGenerator(xml_file_to))  # type: ignore
 
         # Forward the notification


### PR DESCRIPTION
This PR aims to fix two unrelated issues, one with the JSON and one with the XML export:

 - The "ev_oids" field of the Mozilla trust store is filled with empty objects in the JSON export

```
{
	"is_certificate_trusted": true,
	"trust_store": {
		"ev_oids": [
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{},
			{}
		],
		"name": "Mozilla",
		"path": "c:\\program files\\python37\\lib\\site-packages\\sslyze\\plugins\\utils\\trust_store\\pem_files\\mozilla_nss.pem",
		"version": "2018-11-22"
	},
	"verify_string": "ok"
}
```

 - XML export throws an exception related to character encoding:

```
Traceback (most recent call last):
  File "C:\Program Files\Python37\Scripts\sslyze-script.py", line 11, in <module>
    load_entry_point('sslyze==2.0.4', 'console_scripts', 'sslyze')()
  File "c:\program files\python37\lib\site-packages\sslyze\__main__.py", line 117, in main
    output_hub.scans_completed(exec_time)
  File "c:\program files\python37\lib\site-packages\sslyze\cli\output_hub.py", line 67, in scans_completed
    out_generator.scans_completed(total_scan_time)
  File "c:\program files\python37\lib\site-packages\sslyze\cli\xml_output.py", line 104, in scans_completed
    self._file_to.write(xml_final_pretty.decode('utf-8'))
  File "c:\program files\python37\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u0151' in position 21200: character maps to <undefined>
```




