### PR TITLE
Fix DeprecationWarning regarding collections.abc import

### DIFF
--- a/sslyze/utils/thread_pool.py
+++ b/sslyze/utils/thread_pool.py
@@ -1,5 +1,8 @@
 import threading
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 from typing import Tuple, Any, List, Iterable
 
 from queue import Queue


### PR DESCRIPTION
* Use `collections.abc` instead of `collections` to fix `DeprecationWarning` in Python 3.7+

Fixes #367 

