### PR TITLE
Handle case for when object to serialize is of bytes type, fixes #380

### DIFF
--- a/sslyze/cli/json_output.py
+++ b/sslyze/cli/json_output.py
@@ -71,7 +71,7 @@ class JsonOutputGenerator(OutputGenerator):
 
 
 class _CustomJsonEncoder(json.JSONEncoder):
-    def default(self, obj: Any) -> Union[bool, int, float, str, Dict[str, Any]]:
+    def default(self, obj: Any) -> Union[bytes, bool, int, float, str, Dict[str, Any]]:
         if isinstance(obj, Enum):
             result = obj.name
 
@@ -109,6 +109,9 @@ class _CustomJsonEncoder(json.JSONEncoder):
 
         elif isinstance(obj, Path):
             result = str(obj)
+
+        elif isinstance(obj, bytes):
+            result = obj.decode(encoding="utf-8")
 
         elif isinstance(obj, object):
             # Some objects (like str) don't have a __dict__


### PR DESCRIPTION
This fixes the bug in #380. The issue was a bytes object not being handled in `_CustomJsonEncoder`. You can also fix this here:

https://github.com/nabla-c0d3/sslyze/blob/c77ed6396fefac26d19865842e9d5bc847f431be/sslyze/utils/tls_wrapped_protocol_helpers.py#L257

by explicitly passing a string by decoding `self.ERR_NO_STARTTLS`. I'm not sure which method you'd prefer.
I can add a test too if it's helpful - let me know what you think! 

I forgot to post the command I used to reproduce the bug:
`sslyze/__main__.py --tlsv1_2 --json_out=- --starttls=imap imap-mail.outlook.com:110`

and the result I get after the update: 
```
{
    "accepted_targets": [],
    "invalid_targets": [
        {
            "imap-mail.outlook.com:110": "IMAP START TLS was rejected"
        }
    ],
    "sslyze_url": "https://github.com/nabla-c0d3/sslyze",
    "sslyze_version": "2.1.3",
    "total_scan_time": "0.06627202033996582"
}
```