### PR TITLE
Fix crash: Legacy sslclient can not build verified chain

### DIFF
--- a/sslyze/plugins/http_headers_plugin.py
+++ b/sslyze/plugins/http_headers_plugin.py
@@ -57,6 +57,10 @@ class HttpHeadersPlugin(Plugin):
                 verified_chain_as_pem = ssl_connection.ssl_client.get_verified_chain()
             except CouldNotBuildVerifiedChain:
                 verified_chain_as_pem = None
+            except AttributeError:
+                # Only the modern SSL Client can build the verified chain; hence we get here if the server only supports
+                # an older version of TLS (pre 1.2)
+                verified_chain_as_pem = None
 
             # Send an HTTP GET request to the server
             ssl_connection.ssl_client.write(HttpRequestGenerator.get_request(host=server_info.hostname))

--- a/tests/plugin_tests/test_http_headers_plugin.py
+++ b/tests/plugin_tests/test_http_headers_plugin.py
@@ -146,7 +146,7 @@ class TestHttpHeadersPlugin:
         # Given a tls1.0 server
         server_test = ServerConnectivityTester(hostname='tls-v1-0.badssl.com', port=1010)
         server_info = server_test.perform()
-        
+
         # The plugin does not throw an exception trying to access LegacySslClient.get_verified_chain()
         plugin = HttpHeadersPlugin()
         plugin_result = plugin.process_task(server_info, HttpHeadersScanCommand())

--- a/tests/plugin_tests/test_http_headers_plugin.py
+++ b/tests/plugin_tests/test_http_headers_plugin.py
@@ -141,3 +141,15 @@ class TestHttpHeadersPlugin:
         assert plugin_result.expect_ct_header is None
         assert plugin_result.as_text()
         assert plugin_result.as_xml()
+
+    def test_legacy_ssl_client_missing_verified_chain(self):
+        # Given a tls1.0 server
+        server_test = ServerConnectivityTester(hostname='tls-v1-0.badssl.com', port=1010)
+        server_info = server_test.perform()
+        
+        # The plugin does not throw an exception trying to access LegacySslClient.get_verified_chain()
+        plugin = HttpHeadersPlugin()
+        plugin_result = plugin.process_task(server_info, HttpHeadersScanCommand())
+
+        assert plugin_result.as_text()
+        assert plugin_result.as_xml()


### PR DESCRIPTION
Bug: a codepath did not gracefully recover from LegacySSLClient missing get_verified_chain()

Expected result: http_headers_plugin can scan "tls-v1-0.badssl.com:1010"

Actual result: http_headers_plugin throws an exception:
`AttributeError: 'LegacySslClient' object has no attribute 'get_verified_chain'`

