### PR TITLE
Fix detection of symantec-issued certificated

### DIFF
--- a/sslyze/plugins/certificate_info_plugin.py
+++ b/sslyze/plugins/certificate_info_plugin.py
@@ -458,7 +458,7 @@ class CertificateInfoScanResult(PluginScanResult):
                 )
             )
 
-        if self.verified_chain_has_legacy_symantec_anchor is not None:
+        if self.verified_chain_has_legacy_symantec_anchor:
             timeline_str = (
                 "March 2018"
                 if self.verified_chain_has_legacy_symantec_anchor == SymantecDistrustTimelineEnum.MARCH_2018


### PR DESCRIPTION
self.verified_chain_has_legacy_symantec_anchor can be None, False and True. The Symantec Deprecation warning is only accurate if it is actually True.