### PR TITLE
decoded proxy auth header to string from byte string

### DIFF
--- a/sslyze/utils/connection_helpers.py
+++ b/sslyze/utils/connection_helpers.py
@@ -79,7 +79,7 @@ class ProxyTunnelingConnectionHelper(ConnectionHelper):
         else:
             sock.send(
                 self.HTTP_CONNECT_REQ_PROXY_AUTH_BASIC.format(
-                    self._server_host, self._server_port, self._tunnel_basic_auth_token
+                    self._server_host, self._server_port, self._tunnel_basic_auth_token.decode()
                 ).encode("utf-8")
             )
         http_response = HttpResponseParser.parse_from_socket(sock)


### PR DESCRIPTION
When using a proxy to connect to the target URL SSLyze was passing the proxy-authorization as a byte string. Adding .decode() to _tunnel_basic_auth_token before sending it over the socket eliminates this issue. 

Master: 
`CONNECT google.com:443 HTTP/1.1
Proxy-Authorization: Basic b'dXNlcjpwYXNz'`

PR:
`CONNECT google.com:443 HTTP/1.1
Proxy-Authorization: Basic dXNlcjpwYXNz
`

Apologies for any issues with this PR. I've never done one before.
