### PR TITLE
Nmapxml input option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
 
     # Dependencies
     install_requires=[
-        "libnmap",
+        "lxml",
         'nassl>=2.2.0,<2.3.0',
         'cryptography==2.5',
         'tls-parser>=1.2.0,<1.3.0',

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
 
     # Dependencies
     install_requires=[
+        "libnmap",
         'nassl>=2.2.0,<2.3.0',
         'cryptography==2.5',
         'tls-parser>=1.2.0,<1.3.0',

--- a/sslyze/cli/command_line_parser.py
+++ b/sslyze/cli/command_line_parser.py
@@ -215,6 +215,8 @@ class CommandLineParser:
                         if svc.state == 'open':
                             if svc.tunnel == 'ssl':
                                 args_target_list.append("%s:%s" % (host.address, svc.port))
+                    for hostname in host.hostnames:
+                        args_target_list.append("%s:%s" % (hostname, svc.port))
 
             except IOError:
                 raise CommandLineParsingError(

--- a/sslyze/cli/command_line_parser.py
+++ b/sslyze/cli/command_line_parser.py
@@ -217,6 +217,8 @@ class CommandLineParser:
                     for ssl_port in ssl_ports:
                         for address in ssl_port.getparent().getparent().xpath("address/@addr"):
                             ssl_endpoints.add("%s:%s" % (address, ssl_port.get("portid")))
+                        for hostname in ssl_port.getparent().getparent().xpath("hostnames/hostname/@name"):
+                            ssl_endpoints.add("%s:%s" % (hostname, ssl_port.get("portid")))
                     args_target_list.extend(list(ssl_endpoints))
                 else:
                     raise CommandLineParsingError(


### PR DESCRIPTION
Hello !

I'd love to have this feature merged into master as Nmap XML output contain everything needed to identify SSL/TLS enabled services.

Broadly speaking, I iterate over each host and service in the XML file, and each time a service is SSL/TLS enabled, I add to the list of targets:
- the IP/port itself
- every hostname/port combination

Not sure we want to scan all targets, maybe just hostnames are enough, but it will possibly include PTR records as well.

Thoughts ?