### PR TITLE
Change import sha256

### DIFF
--- a/sslyze/plugins/certificate_info/_certificate_utils.py
+++ b/sslyze/plugins/certificate_info/_certificate_utils.py
@@ -1,4 +1,4 @@
-from _sha256 import sha256
+from hashlib import sha256
 from typing import List, cast
 
 from cryptography import x509


### PR DESCRIPTION
Import from _sha256 does not work on RHEL8 / CenOS8. Changed it to an import from hashlib.