### PR TITLE
Added flag for amount of client-initiated renegotiation attempts

### DIFF
--- a/sslyze/plugins/session_renegotiation_plugin.py
+++ b/sslyze/plugins/session_renegotiation_plugin.py
@@ -1,4 +1,4 @@
-#import socket
+import socket
 from concurrent.futures._base import Future
 from dataclasses import dataclass
 from enum import Enum
@@ -79,8 +79,8 @@ class _SessionRenegotiationCliConnector(ScanCommandCliConnector[SessionRenegotia
                 cir = int(cir)
                 if not is_scan_cmd_enabled:
                     raise ScanCommandWrongUsageError(f"Option --cir cannot be used without --reneg (or --regular)!")
-                #if not isinstance(cir, int):
-                #    raise TypeError(f"Expected an int for cir but received {cir}")
+                if cir < 0:
+                    raise TypeError(f"Expected positive int for cir but received {cir}")
                 extra_arguments = SessionRenegotiationExtraArguments(cir)
         except KeyError:
             pass

--- a/sslyze/plugins/session_renegotiation_plugin.py
+++ b/sslyze/plugins/session_renegotiation_plugin.py
@@ -1,13 +1,14 @@
-import socket
+#import socket
 from concurrent.futures._base import Future
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from nassl._nassl import OpenSSLError
 from nassl.legacy_ssl_client import LegacySslClient
 
 from sslyze.plugins.plugin_base import (
+    OptParseCliOption,
     ScanCommandImplementation,
     ScanCommandExtraArguments,
     ScanJob,
@@ -17,6 +18,15 @@ from sslyze.plugins.plugin_base import (
 )
 from sslyze.server_connectivity import ServerConnectivityInfo, TlsVersionEnum
 
+@dataclass(frozen=True)
+class SessionRenegotiationExtraArguments(ScanCommandExtraArguments):
+    """Additional configuration for running the RENEG scan command.
+
+    Attributes:
+        cir: Maximum amount of attempts for client-initiated renegotiation.
+    """
+
+    cir: int
 
 @dataclass(frozen=True)
 class SessionRenegotiationScanResult(ScanCommandResult):
@@ -27,7 +37,7 @@ class SessionRenegotiationScanResult(ScanCommandResult):
         supports_secure_renegotiation: True if the server supports secure renegotiation.
     """
 
-    accepts_client_renegotiation: bool
+    accepts_client_renegotiation: int
     supports_secure_renegotiation: bool
 
 
@@ -36,21 +46,56 @@ class _ScanJobResultEnum(Enum):
     SUPPORTS_SECURE_RENEG = 2
 
 
-class _SessionRenegotiationCliConnector(ScanCommandCliConnector[SessionRenegotiationScanResult, None]):
+class _SessionRenegotiationCliConnector(ScanCommandCliConnector[SessionRenegotiationScanResult, SessionRenegotiationExtraArguments]):
 
     _cli_option = "reneg"
     _cli_description = "Test a server for for insecure TLS renegotiation and client-initiated renegotiation."
+
+    @classmethod
+    def get_cli_options(cls) -> List[OptParseCliOption]:
+        scan_command_option = super().get_cli_options()
+        scan_command_option.append(
+            OptParseCliOption(
+                option="cir",
+                help="Amount of client-initiated renegotiation attempts. Must be used with --reneg",
+                action="store",
+            )
+        )
+        return scan_command_option
+
+    @classmethod
+    def find_cli_options_in_command_line(
+        cls, parsed_command_line: Dict[str, Union[None, bool, str]]
+    ) -> Tuple[bool, Optional["SessionRenegotiationExtraArguments"]]:
+
+        # check if --reneg was used - currently not relevant
+        is_scan_cmd_enabled, _ = super().find_cli_options_in_command_line(parsed_command_line)
+
+        # check if --cir was used
+        extra_arguments = None
+        try:
+            cir = parsed_command_line["cir"]
+            if cir:
+                cir = int(cir)
+                if not is_scan_cmd_enabled:
+                    raise ScanCommandWrongUsageError(f"Option --cir cannot be used without --reneg (or --regular)!")
+                #if not isinstance(cir, int):
+                #    raise TypeError(f"Expected an int for cir but received {cir}")
+                extra_arguments = SessionRenegotiationExtraArguments(cir)
+        except KeyError:
+            pass
+
+        return is_scan_cmd_enabled, extra_arguments
 
     @classmethod
     def result_to_console_output(cls, result: SessionRenegotiationScanResult) -> List[str]:
         result_txt = [cls._format_title("Session Renegotiation")]
 
         # Client-initiated reneg
-        client_reneg_txt = (
-            "VULNERABLE - Server honors client-initiated renegotiations"
-            if result.accepts_client_renegotiation
-            else "OK - Rejected"
-        )
+        if result.accepts_client_renegotiation > 0:
+            client_reneg_txt = "VULNERABLE - Worked " + str(result.accepts_client_renegotiation) + " times!"
+        else:
+            client_reneg_txt = "OK - Rejected"
         result_txt.append(cls._format_field("Client-initiated Renegotiation:", client_reneg_txt))
 
         # Secure reneg
@@ -72,11 +117,9 @@ class SessionRenegotiationImplementation(ScanCommandImplementation[SessionRenego
 
     @classmethod
     def scan_jobs_for_scan_command(
-        cls, server_info: ServerConnectivityInfo, extra_arguments: Optional[ScanCommandExtraArguments] = None
+        cls, server_info: ServerConnectivityInfo, extra_arguments: Optional[SessionRenegotiationExtraArguments] = None
     ) -> List[ScanJob]:
-        if extra_arguments:
-            raise ScanCommandWrongUsageError("This plugin does not take extra arguments")
-
+        cir = str(extra_arguments.cir) if extra_arguments else 1
         # Try with TLS 1.2 even if the server supports TLS 1.3 or higher as there is no reneg with TLS 1.3
         if server_info.tls_probing_result.highest_tls_version_supported.value >= TlsVersionEnum.TLS_1_3.value:
             tls_version_to_use = TlsVersionEnum.TLS_1_2
@@ -85,7 +128,7 @@ class SessionRenegotiationImplementation(ScanCommandImplementation[SessionRenego
 
         return [
             ScanJob(function_to_call=_test_secure_renegotiation, function_arguments=[server_info, tls_version_to_use]),
-            ScanJob(function_to_call=_test_client_renegotiation, function_arguments=[server_info, tls_version_to_use]),
+            ScanJob(function_to_call=_test_client_renegotiation, function_arguments=[server_info, tls_version_to_use, cir]),
         ]
 
     @classmethod
@@ -129,8 +172,8 @@ def _test_secure_renegotiation(
 
 
 def _test_client_renegotiation(
-    server_info: ServerConnectivityInfo, tls_version_to_use: TlsVersionEnum
-) -> Tuple[_ScanJobResultEnum, bool]:
+    server_info: ServerConnectivityInfo, tls_version_to_use: TlsVersionEnum, cir: int
+) -> Tuple[_ScanJobResultEnum, int]:
     """Check whether the server honors session renegotiation requests.
     """
     ssl_connection = server_info.get_preconfigured_tls_connection(
@@ -142,45 +185,46 @@ def _test_client_renegotiation(
     try:
         # Perform the SSL handshake
         ssl_connection.connect()
-
+        i = 0
         try:
             # Let's try to renegotiate
-            ssl_connection.ssl_client.do_renegotiate()
-            accepts_client_renegotiation = True
+            for i in range(int(cir)):
+                ssl_connection.ssl_client.do_renegotiate()
+                accepts_client_renegotiation = i + 1 # Python ranges, there is no 0th attempt
 
-        # Errors caused by a server rejecting the renegotiation
+        #Errors caused by a server rejecting the renegotiation
         except socket.timeout:
             # This is how Netty rejects a renegotiation - https://github.com/nabla-c0d3/sslyze/issues/114
-            accepts_client_renegotiation = False
+            accepts_client_renegotiation = i
         except ConnectionError:
-            accepts_client_renegotiation = False
+            accepts_client_renegotiation = i
         except OSError as e:
             # OSError is the parent of all (non-TLS) socket/connection errors so it should be last
             if "Nassl SSL handshake failed" in e.args[0]:
                 # Special error returned by nassl
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             else:
                 raise
         except OpenSSLError as e:
             if "handshake failure" in e.args[0]:
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             elif "no renegotiation" in e.args[0]:
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             elif "tlsv1 unrecognized name" in e.args[0]:
                 # Yahoo's very own way of rejecting a renegotiation
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             elif "tlsv1 alert internal error" in e.args[0]:
                 # Jetty server: https://github.com/nabla-c0d3/sslyze/issues/290
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             elif "decryption failed or bad record mac" in e.args[0]:
                 # Some servers such as reddit.com
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             elif "sslv3 alert unexpected message" in e.args[0]:
                 # traefik https://github.com/nabla-c0d3/sslyze/issues/422
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
             elif "shut down by peer" in e.args[0]:
                 # Cloudfront
-                accepts_client_renegotiation = False
+                accepts_client_renegotiation = i
 
             else:
                 raise

--- a/sslyze/plugins/session_renegotiation_plugin.py
+++ b/sslyze/plugins/session_renegotiation_plugin.py
@@ -1,4 +1,4 @@
-#import socket
+import socket
 from concurrent.futures._base import Future
 from dataclasses import dataclass
 from enum import Enum


### PR DESCRIPTION
Implements Feature Request #473, fixing Issue #38
To do so, the vulnerability output for the client-initiated renegotiation was also edited to better reflect the results (now shows how many attempts worked - non-vulnerability report looks similar to before).

Currently, the flag only works when --reneg is present (also with --regular, as it is a shortcut that contains --reneg). I Could not figure out how to do it properly and since I am not familiar with the cli interface, I suppose you could do a faster and better job than me.

Default for the flag is 1, so if it is left out, the old behaviour is met (except for the output).