### PR TITLE
Fix attribute name when printing unsuccessful OCSP response status

### DIFF
--- a/sslyze/plugins/certificate_info/_cli_connector.py
+++ b/sslyze/plugins/certificate_info/_cli_connector.py
@@ -231,7 +231,7 @@ class _CertificateInfoCliConnector(
                     cls._format_field(
                         "",
                         "ERROR - OCSP response status is not successful: {}".format(
-                            cert_deployment.ocsp_response.status.name
+                            cert_deployment.ocsp_response.response_status.name
                         ),
                     )
                 ]


### PR DESCRIPTION
This used to throw an `AttributeError` since the incorrect attribute name was specified. E.g.

```
➜ python -m sslyze --regular e-saksham.nic.in

 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   e-saksham.nic.in:443                       => 164.100.229.145 




Traceback (most recent call last):
  File "/home/faheel/.asdf/installs/python/3.8.6/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/faheel/.asdf/installs/python/3.8.6/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/faheel/.local/lib/python3.8/site-packages/sslyze/__main__.py", line 84, in <module>
    main()
  File "/home/faheel/.local/lib/python3.8/site-packages/sslyze/__main__.py", line 76, in main
    output_hub.server_scan_completed(scan_result)
  File "/home/faheel/.local/lib/python3.8/site-packages/sslyze/cli/output_hub.py", line 53, in server_scan_completed
    out_generator.server_scan_completed(server_scan_result)
  File "/home/faheel/.local/lib/python3.8/site-packages/sslyze/cli/console_output.py", line 75, in server_scan_completed
    for line in cli_connector_cls.result_to_console_output(scan_command_result):
  File "/home/faheel/.local/lib/python3.8/site-packages/sslyze/plugins/certificate_info/_cli_connector.py", line 92, in result_to_console_output
    result_as_txt.extend(cls._cert_deployment_to_console_output(index, cert_deployment))
  File "/home/faheel/.local/lib/python3.8/site-packages/sslyze/plugins/certificate_info/_cli_connector.py", line 234, in _cert_deployment_to_console_output
    cert_deployment.ocsp_response.status.name
AttributeError: '_OCSPResponse' object has no attribute 'status'
```