### PR TITLE
Output handling should not close sys.stdout

### DIFF
--- a/sslyze/cli/console_output.py
+++ b/sslyze/cli/console_output.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-from typing import cast, TextIO, Optional
+from typing import cast, Optional
 
 from sslyze import __version__
 from sslyze.cli.command_line_parser import ParsedCommandLine
-from sslyze.cli.output_generator import OutputGenerator
+from sslyze.cli.output_generator import OutputGenerator, OutputType
 
 from sslyze.errors import ConnectionToServerFailed
 from sslyze.plugins.plugin_base import ScanCommandWrongUsageError
@@ -18,7 +18,7 @@ from sslyze.server_setting import (
 
 
 class ConsoleOutputGenerator(OutputGenerator):
-    def __init__(self, file_to: TextIO) -> None:
+    def __init__(self, file_to: OutputType) -> None:
         super().__init__(file_to)
         self._json_path_out: Optional[Path] = None  # Used to print the path where the JSON output was written
 

--- a/sslyze/cli/json_output.py
+++ b/sslyze/cli/json_output.py
@@ -1,10 +1,10 @@
 import json
 from dataclasses import asdict, dataclass
-from typing import TextIO, List
+from typing import List
 
 from sslyze.__version__ import __url__, __version__
 from sslyze.cli.command_line_parser import ParsedCommandLine
-from sslyze.cli.output_generator import OutputGenerator
+from sslyze.cli.output_generator import OutputGenerator, OutputType
 from sslyze.errors import ConnectionToServerFailed
 from sslyze.json import JsonEncoder
 from sslyze.scanner import ServerScanResult
@@ -30,7 +30,7 @@ class _SslyzeOutputAsJson:
 
 
 class JsonOutputGenerator(OutputGenerator):
-    def __init__(self, file_to: TextIO) -> None:
+    def __init__(self, file_to: OutputType) -> None:
         super().__init__(file_to)
         self._server_connectivity_errors: List[_ServerConnectivityErrorAsJson] = []
         self._server_scan_results: List[ServerScanResult] = []

--- a/sslyze/cli/output_hub.py
+++ b/sslyze/cli/output_hub.py
@@ -1,10 +1,10 @@
 import sys
-from typing import List
+from typing import List, Optional
 
 from sslyze.cli.command_line_parser import ParsedCommandLine
 from sslyze.cli.console_output import ConsoleOutputGenerator
 from sslyze.cli.json_output import JsonOutputGenerator
-from sslyze.cli.output_generator import OutputGenerator
+from sslyze.cli.output_generator import OutputGenerator, OutputType
 from sslyze.errors import ConnectionToServerFailed
 from sslyze.scanner import ServerScanResult
 from sslyze.server_connectivity import ServerConnectivityInfo
@@ -23,11 +23,11 @@ class OutputHub:
             self._output_generator_list.append(ConsoleOutputGenerator(sys.stdout))
 
         # Setup JSON output if needed
-        json_file_out = None
+        json_file_out: Optional[OutputType] = None
         if parsed_command_line.should_print_json_to_console:
             json_file_out = sys.stdout
         elif parsed_command_line.json_path_out:
-            json_file_out = parsed_command_line.json_path_out.open("wt", encoding="utf-8")
+            json_file_out = parsed_command_line.json_path_out
 
         if json_file_out:
             self._output_generator_list.append(JsonOutputGenerator(json_file_out))


### PR DESCRIPTION
When sslyze is used as library in other code, ``sys.stdout`` is closed after a complete scan.

Investigation showed, that ``OutputGenerator`` closes the ``TextIO`` it gets, even when this is ``sys.stdout``. Imho the ``OutputGenerator`` should only close streams it opened itself, as if it gets a stream from outside, the outside code is responsible of closing this stream.