### PR TITLE
Fixed missing spaces in the help of --regular

### DIFF
--- a/sslyze/cli/command_line_parser.py
+++ b/sslyze/cli/command_line_parser.py
@@ -123,7 +123,7 @@ class CommandLineParser:
             "--regular",
             action="store_true",
             dest=None,
-            help=f"Regular HTTPS scan; shortcut for --{'--'.join(self.REGULAR_CMD)}",
+            help=f"Regular HTTPS scan; shortcut for --{' --'.join(self.REGULAR_CMD)}",
         )
 
     def parse_command_line(self) -> ParsedCommandLine:


### PR DESCRIPTION
Hi

This fixes the wrong output of the help of `--regular`. Spaces before the `--` were missing.

Before:
```
# sslyze -h
Usage: sslyze [options] target1.com target2.com:443 target3.com:443{ip} etc...

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  --regular             Regular HTTPS scan; shortcut for --sslv2--sslv3--tlsv1
                        --tlsv1_1--tlsv1_2--tlsv1_3--reneg--resum--certinfo--
                        hide_rejected_ciphers--compression--heartbleed--
                        openssl_ccs--fallback--robot--elliptic_curves

[...]
```

After:
```
# sslyze -h
Usage: sslyze [options] target1.com target2.com:443 target3.com:443{ip} etc...

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  --regular             Regular HTTPS scan; shortcut for --sslv2 --sslv3
                        --tlsv1 --tlsv1_1 --tlsv1_2 --tlsv1_3 --reneg --resum
                        --certinfo --hide_rejected_ciphers --compression
                        --heartbleed --openssl_ccs --fallback --robot
                        --elliptic_curves

[...]
```

Best,
Emanuel