### PR TITLE
Upgrading Build Workflow to publish Docker Images on each Release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.pytest_cache
+**/__pycache__
+/tests
+/docs
+/.github

--- a/.github/workflows/build_windows_exe.yml
+++ b/.github/workflows/build_windows_exe.yml
@@ -1,4 +1,4 @@
-name: Build Windows Executable
+name: "Build Windows Executable"
 
 on:
   push:

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,16 +1,9 @@
 name: "Release Build"
 on:
-  push:
   release:
     types: [released]
 
 env:
-  # ---- Language Versions ----
-
-  PYTHON_VERSION: "3.9"
-
-  # ---- Docker Namespace ----
-
   # DOCKER_USER and DOCKER_TOKEN must be stored as GitHub secrets as well
   DOCKER_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE }}
 

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,0 +1,52 @@
+name: "Release Build"
+on:
+  push:
+  release:
+    types: [released]
+
+env:
+  # ---- Language Versions ----
+
+  PYTHON_VERSION: "3.9"
+
+  # ---- Docker Namespace ----
+
+  # DOCKER_USER and DOCKER_TOKEN must be stored as GitHub secrets as well
+  DOCKER_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE }}
+
+jobs:
+
+  docker-release-build:
+    name: SSlyze Docker Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker Meta
+        id: docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKER_NAMESPACE }}/sslyze
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/release-to-docker.yml
+++ b/.github/workflows/release-to-docker.yml
@@ -1,4 +1,4 @@
-name: "Release Build"
+name: "Release to Docker"
 on:
   release:
     types: [released]

--- a/.github/workflows/scan_apache2_server.yml
+++ b/.github/workflows/scan_apache2_server.yml
@@ -2,40 +2,42 @@ name: Scan Apache2 Web Server
 
 on:
   push:
-    branches: [ release ]
+    branches: [release]
   pull_request:
-    branches: [ release ]
+    branches: [release]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Apache2
-      run: |
-        sudo apt-get install apache2
-        sudo cp ./tests/web_servers/apache2/000-default.conf /etc/apache2/sites-enabled/000-default.conf
-        sudo cp ./tests/web_servers/apache2/apache-selfsigned.crt /etc/ssl/certs/apache-selfsigned.crt
-        sudo cp ./tests/web_servers/apache2/apache-selfsigned.key /etc/ssl/private/apache-selfsigned.key
-        sudo a2enmod ssl
+      - name: Install Apache2
+        run: |
+          sudo apt-get install apache2
+          sudo cp ./tests/web_servers/apache2/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+          sudo cp ./tests/web_servers/apache2/apache-selfsigned.crt /etc/ssl/certs/apache-selfsigned.crt
+          sudo cp ./tests/web_servers/apache2/apache-selfsigned.key /etc/ssl/private/apache-selfsigned.key
+          sudo a2enmod ssl
 
-    - name: Start Apache2
-      # Start apache2 and display the status if it starting it failed
-      run: sudo /etc/init.d/apache2 restart || systemctl status apache2.service
+      - name: Start Apache2
+        # Start apache2 and display the status if it starting it failed
+        run: sudo /etc/init.d/apache2 restart || systemctl status apache2.service
 
-    - name: Install pip
-      run: |
-        python -m pip install --upgrade pip setuptools
+      - name: Install pip
+        run: |
+          python -m pip install --upgrade pip setuptools
 
-    - name: Install SSLyze
-      run: python setup.py install
+      - name: Install SSLyze
+        run: python setup.py install
 
-    - name: Scan web server
-      run: python tests/web_servers/scan_localhost.py apache2
+      - name: Scan web server
+        run: python tests/web_servers/scan_localhost.py apache2

--- a/.github/workflows/scan_apache2_server.yml
+++ b/.github/workflows/scan_apache2_server.yml
@@ -9,16 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
 
       - name: Install Apache2
         run: |

--- a/.github/workflows/scan_iis_server.yml
+++ b/.github/workflows/scan_iis_server.yml
@@ -2,38 +2,40 @@ name: Scan IIS Web Server
 
 on:
   push:
-    branches: [ release ]
+    branches: [release]
   pull_request:
-    branches: [ release ]
+    branches: [release]
 
 jobs:
   build:
-
     runs-on: windows-2019
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install IIS
-      run: |
-        Install-WindowsFeature -name Web-Server -IncludeManagementTools -IncludeAllSubFeature
-        Import-Module IISAdministration
-        # Generate a self-signed cert
-        $Cert = New-SelfSignedCertificate -DnsName "TestSite" -KeyAlgorithm RSA -KeyLength 2048 -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddYears(10)
-        $ThumbPrint = $Cert.Thumbprint
-        # Create an HTTPS binding with the self-signed cert
-        New-IISSiteBinding -Name "Default Web Site" -BindingInformation "*:443:" -CertificateThumbPrint $ThumbPrint -CertStoreLocation "Cert:\LocalMachine\My" -Protocol https
+      - name: Install IIS
+        run: |
+          Install-WindowsFeature -name Web-Server -IncludeManagementTools -IncludeAllSubFeature
+          Import-Module IISAdministration
+          # Generate a self-signed cert
+          $Cert = New-SelfSignedCertificate -DnsName "TestSite" -KeyAlgorithm RSA -KeyLength 2048 -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddYears(10)
+          $ThumbPrint = $Cert.Thumbprint
+          # Create an HTTPS binding with the self-signed cert
+          New-IISSiteBinding -Name "Default Web Site" -BindingInformation "*:443:" -CertificateThumbPrint $ThumbPrint -CertStoreLocation "Cert:\LocalMachine\My" -Protocol https
 
-    - name: Install pip
-      run: |
-        python -m pip install --upgrade pip setuptools
+      - name: Install pip
+        run: |
+          python -m pip install --upgrade pip setuptools
 
-    - name: Install SSLyze
-      run: python setup.py install
+      - name: Install SSLyze
+        run: python setup.py install
 
-    - name: Scan web server
-      run: python tests/web_servers/scan_localhost.py iis
+      - name: Scan web server
+        run: python tests/web_servers/scan_localhost.py iis

--- a/.github/workflows/scan_iis_server.yml
+++ b/.github/workflows/scan_iis_server.yml
@@ -9,16 +9,13 @@ on:
 jobs:
   build:
     runs-on: windows-2019
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
 
       - name: Install IIS
         run: |

--- a/.github/workflows/scan_nginx_server.yml
+++ b/.github/workflows/scan_nginx_server.yml
@@ -9,16 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
 
       - name: Install Nginx
         run: |

--- a/.github/workflows/scan_nginx_server.yml
+++ b/.github/workflows/scan_nginx_server.yml
@@ -2,37 +2,39 @@ name: Scan Nginx Web Server
 
 on:
   push:
-    branches: [ release ]
+    branches: [release]
   pull_request:
-    branches: [ release ]
+    branches: [release]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Nginx
-      run: |
-        sudo apt-get install nginx -y
-        sudo cp ./tests/web_servers/nginx/default  /etc/nginx/sites-available/default
+      - name: Install Nginx
+        run: |
+          sudo apt-get install nginx -y
+          sudo cp ./tests/web_servers/nginx/default  /etc/nginx/sites-available/default
 
-    - name: Start Nginx
-      # Start nginx and display the status if it starting it failed
-      run: sudo /etc/init.d/nginx restart || systemctl status nginx.service
+      - name: Start Nginx
+        # Start nginx and display the status if it starting it failed
+        run: sudo /etc/init.d/nginx restart || systemctl status nginx.service
 
-    - name: Install pip
-      run: |
-        python -m pip install --upgrade pip setuptools
+      - name: Install pip
+        run: |
+          python -m pip install --upgrade pip setuptools
 
-    - name: Install SSLyze
-      run: python setup.py install
+      - name: Install SSLyze
+        run: python setup.py install
 
-    - name: Scan web server
-      run: python tests/web_servers/scan_localhost.py nginx
+      - name: Scan web server
+        run: python tests/web_servers/scan_localhost.py nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 RUN pip install sslyze
+RUN adduser -S -H -u 1001 sslyze
+USER sslyze
 ENTRYPOINT ["sslyze"]
 CMD ["-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM python:3.9-slim
-RUN pip install sslyze
-RUN adduser -S -H -u 1001 sslyze
+COPY . /sslyze/
+# install latest updates as root
+RUN apt-get update \
+        && apt-get install -y sudo
+# install sslyze based on sourcecode
+RUN python -m pip install --upgrade pip setuptools \
+        && pip install -r /sslyze/requirements.txt
+# set user to a non-root user sslyze
+RUN adduser --no-create-home --disabled-password --gecos "" --uid 1001 sslyze
 USER sslyze
-ENTRYPOINT ["sslyze"]
+# restrict execution to sslyze
+WORKDIR /sslyze
+ENTRYPOINT ["python", "-m", "sslyze"]
 CMD ["-h"]


### PR DESCRIPTION
This PR if applied closes #521 by upgrading the sslyze repository GitHub Actions and Workflows.

* Updated the Docker Image to the newest Python image `3.9-slim` and switched the installation process to a source based instead of pip to prevent race conditions in the release process 
* Added a new release pipeline which will be triggered with every new GitHub release to publish the corresponding Docker Image to DockerHub. To get this work you have to add 3 new repository secrets with the namespace and a docker user with `red & write` permission for the docker repository:
  * DOCKER_NAMESPACE: `nablac0d3`
  * DOCKER_USERNAME: `nablac0d3`
  * DOCKER_TOKEN: _YOUR_USER_PASSWORD_
  
  I tested the release pipeline already within our fork successfully (with our project docker repo instead): https://github.com/secureCodeBox/sslyze/runs/3722635578?check_suite_focus=true