### PR TITLE
Rename Mozilla configuration option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Checking results against Mozilla's "intermediate" configuration. See https://ssl
 mozilla.com:443: OK - Compliant.
 ```
 
-The Mozilla configuration to check against can be configured via `--mozilla-config={old, intermediate, modern}`:
+The Mozilla configuration to check against can be configured via `--mozilla_config={old, intermediate, modern}`:
 ```
-$ python -m sslyze --mozilla-config=modern mozilla.com
+$ python -m sslyze --mozilla_config=modern mozilla.com
 ```
 ```
 Checking results against Mozilla's "modern" configuration. See https://ssl-config.mozilla.org/ for more details.


### PR DESCRIPTION
Option --mozilla-config was renamed to --mozilla_config in 769653726e472b50a5382512a91f9be0baa73b33