### PR TITLE
Allow hostnames to include a path

### DIFF
--- a/sslyze/plugins/certificate_info/_cert_chain_analyzer.py
+++ b/sslyze/plugins/certificate_info/_cert_chain_analyzer.py
@@ -314,7 +314,7 @@ def _certificate_matches_hostname(certificate: Certificate, server_hostname: str
     }
     # CertificateError is raised on failure
     try:
-        match_hostname(certificate_names, server_hostname)  # type: ignore
+        match_hostname(certificate_names, server_hostname.split("/")[0])  # type: ignore
         return True
     except CertificateError:
         return False

--- a/sslyze/server_setting.py
+++ b/sslyze/server_setting.py
@@ -114,7 +114,7 @@ class ServerNetworkLocation:
 
 def _do_dns_lookup(hostname: str, port: int) -> str:
     try:
-        addr_infos = socket.getaddrinfo(hostname, port, socket.AF_UNSPEC, socket.IPPROTO_IP)
+        addr_infos = socket.getaddrinfo(hostname.split("/")[0], port, socket.AF_UNSPEC, socket.IPPROTO_IP)
     except (socket.gaierror, IndexError, ConnectionError):
         raise ServerHostnameCouldNotBeResolved(f"Could not resolve {hostname}")
 


### PR DESCRIPTION
In my usage of SSLyze I ran into a number of hosts which only respond under certain paths but not under at the root. Additionally, it is possible to have a configuration in Kubernetes where example.com/server1 is served by a completely different server than example.com/server2.

Therefore it is important that SSLyze can handle these as separate targets. The only blockers seem to have been the DNS lookup (because there, of course, you can't resolve the path) and certificate matching.