### PR TITLE
Use ORM mode for HttpProxySettings

### DIFF
--- a/sslyze/json/json_output.py
+++ b/sslyze/json/json_output.py
@@ -101,7 +101,7 @@ class AllScanCommandsAttemptsAsJson(_BaseModelWithOrmModeAndForbid):
 
 
 # Identical fields in the JSON output
-class _HttpProxySettingsAsJson(pydantic.BaseModel):
+class _HttpProxySettingsAsJson(_BaseModelWithOrmModeAndForbid):
     hostname: str
     port: int
 


### PR DESCRIPTION
Fix pydantic.error_wrappers.ValidationError when using an HTTP proxy and writing JSON output.