### PR TITLE
Bump minimum required pyopenssl version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "cryptography>=2.6,<40",
         "tls-parser>=2,<3",
         "pydantic>=1.7,<1.11",
-        "pyOpenSSL>=20,<24",
+        "pyOpenSSL>=23,<24",
     ],
     # cx_freeze info for Windows builds with Python embedded
     options={"build_exe": {"packages": ["cffi", "cryptography"], "include_files": get_include_files()}},


### PR DESCRIPTION
Older versions of pyopenssl raise an exception [here](https://github.com/nabla-c0d3/sslyze/blob/release/sslyze/plugins/certificate_info/trust_stores/trust_store.py#L54), as older versions expect a `Union[str, bytes]` instead of `pathlib.Path`. Versions `>=23.0.0` can handle a `Path` here.

Another way to fix this while maintaining compatibility with older versions of pyopenssl would be to insert `.as_posix()` at this call site, but I'm unsure whether there are other call sites in the codebase incompatible with the older pyopenssl versions.