### PR TITLE
Update version of Mozilla TLS config to 5.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_include_files() -> List[Tuple[str, str]]:
             non_python_files.append((file, path.join("pem_files", filename)))
 
     # The Mozilla profile
-    mozilla_profile_path = root_path / "sslyze" / "mozilla_tls_profile" / "5.6.json"
+    mozilla_profile_path = root_path / "sslyze" / "mozilla_tls_profile" / "5.7.json"
     non_python_files.append((str(mozilla_profile_path), mozilla_profile_path.name))
     return non_python_files
 
@@ -93,7 +93,7 @@ setup(
     package_data={
         "sslyze": ["py.typed"],
         "sslyze.plugins.certificate_info.trust_stores": ["pem_files/*.pem", "pem_files/*.yaml"],
-        "sslyze.mozilla_tls_profile": ["5.6.json"],
+        "sslyze.mozilla_tls_profile": ["5.7.json"],
     },
     entry_points={"console_scripts": ["sslyze = sslyze.__main__:main"]},
     # Dependencies

--- a/sslyze/mozilla_tls_profile/5.7.json
+++ b/sslyze/mozilla_tls_profile/5.7.json
@@ -1,6 +1,6 @@
 {
-    "version": 5.6,
-    "href": "https://ssl-config.mozilla.org/guidelines/5.6.json",
+    "version": 5.7,
+    "href": "https://ssl-config.mozilla.org/guidelines/5.7.json",
     "configurations": {
         "modern": {
             "certificate_curves": ["prime256v1", "secp384r1"],
@@ -58,7 +58,8 @@
                     "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
                     "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
                     "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-                    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+                    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
                 ],
                 "openssl": [
                     "ECDHE-ECDSA-AES128-GCM-SHA256",
@@ -68,7 +69,8 @@
                     "ECDHE-ECDSA-CHACHA20-POLY1305",
                     "ECDHE-RSA-CHACHA20-POLY1305",
                     "DHE-RSA-AES128-GCM-SHA256",
-                    "DHE-RSA-AES256-GCM-SHA384"
+                    "DHE-RSA-AES256-GCM-SHA384",
+                    "DHE-RSA-CHACHA20-POLY1305"
                 ]
             },
             "ciphersuites": [

--- a/sslyze/mozilla_tls_profile/mozilla_config_checker.py
+++ b/sslyze/mozilla_tls_profile/mozilla_config_checker.py
@@ -101,7 +101,7 @@ class MozillaTlsConfigurationChecker:
 
     @classmethod
     def get_default(cls) -> "MozillaTlsConfigurationChecker":
-        json_profile_path = Path(__file__).parent.absolute() / "5.6.json"
+        json_profile_path = Path(__file__).parent.absolute() / "5.7.json"
         json_profile_as_str = json_profile_path.read_text()
         parsed_profile = _MozillaTlsProfileAsJson(**json.loads(json_profile_as_str))
         return cls(parsed_profile)


### PR DESCRIPTION
Update the version of the Mozilla TLS configuration recommendations to version 5.7

Fixes #608 