### PR TITLE
Include SMTP EHLO rejection response in raised exception

### DIFF
--- a/sslyze/connection_helpers/opportunistic_tls_helpers.py
+++ b/sslyze/connection_helpers/opportunistic_tls_helpers.py
@@ -67,8 +67,9 @@ class _SmtpHelper(_OpportunisticTlsHelper):
 
         # Send a EHLO and wait for the 250 status
         sock.send(b"EHLO sslyze.scan\r\n")
-        if b"250 " not in sock.recv(2048):
-            raise OpportunisticTlsError("SMTP EHLO was rejected")
+        data = sock.recv(2048)
+        if b"250 " not in data:
+            raise OpportunisticTlsError(f"SMTP EHLO was rejected: {repr(data)}")
 
         # Send a STARTTLS
         sock.send(b"STARTTLS\r\n")


### PR DESCRIPTION
This can help when debugging the rejection reason. In particular, some servers do this when rate limiting, which is usually apparent from their response.