### PR TITLE
Add support for custom SMTP EHLO hostname

### DIFF
--- a/sslyze/connection_helpers/opportunistic_tls_helpers.py
+++ b/sslyze/connection_helpers/opportunistic_tls_helpers.py
@@ -61,12 +61,15 @@ class _OpportunisticTlsHelper(ABC):
 class _SmtpHelper(_OpportunisticTlsHelper):
     """Perform an SMTP StartTLS negotiation."""
 
+    def __init__(self, smtp_ehlo_hostname: str):
+        self._smtp_ehlo_hostname = smtp_ehlo_hostname
+
     def prepare_socket_for_tls_handshake(self, sock: socket.socket) -> None:
         # Get the SMTP banner
         sock.recv(2048)
 
         # Send a EHLO and wait for the 250 status
-        sock.send(b"EHLO sslyze.scan\r\n")
+        sock.send(f"EHLO {self._smtp_ehlo_hostname}\r\n".encode("ascii"))
         if b"250 " not in sock.recv(2048):
             raise OpportunisticTlsError("SMTP EHLO was rejected")
 
@@ -223,14 +226,16 @@ _START_TLS_HELPER_CLASSES = {
 
 
 def get_opportunistic_tls_helper(
-    protocol: ProtocolWithOpportunisticTlsEnum, xmpp_to_hostname: Optional[str]
+    protocol: ProtocolWithOpportunisticTlsEnum, xmpp_to_hostname: Optional[str], smtp_ehlo_hostname: str
 ) -> _OpportunisticTlsHelper:
     helper_cls = _START_TLS_HELPER_CLASSES[protocol]
-    if protocol not in [ProtocolWithOpportunisticTlsEnum.XMPP, ProtocolWithOpportunisticTlsEnum.XMPP_SERVER]:
-        opportunistic_tls_helper = helper_cls()
-    else:
+    if protocol in [ProtocolWithOpportunisticTlsEnum.XMPP, ProtocolWithOpportunisticTlsEnum.XMPP_SERVER]:
         if xmpp_to_hostname is None:
             raise ValueError("Received None for xmpp_to_hostname")
         opportunistic_tls_helper = helper_cls(xmpp_to=xmpp_to_hostname)
+    elif protocol == ProtocolWithOpportunisticTlsEnum.SMTP:
+        opportunistic_tls_helper = helper_cls(smtp_ehlo_hostname)
+    else:
+        opportunistic_tls_helper = helper_cls()
 
     return opportunistic_tls_helper

--- a/sslyze/connection_helpers/tls_connection.py
+++ b/sslyze/connection_helpers/tls_connection.py
@@ -231,7 +231,9 @@ class SslConnection:
         # Do the Opportunistic/StartTLS negotiation if needed
         if self._network_configuration.tls_opportunistic_encryption:
             opportunistic_tls_helper = get_opportunistic_tls_helper(
-                self._network_configuration.tls_opportunistic_encryption, self._network_configuration.xmpp_to_hostname
+                self._network_configuration.tls_opportunistic_encryption,
+                self._network_configuration.xmpp_to_hostname,
+                self._network_configuration.smtp_ehlo_hostname,
             )
             try:
                 opportunistic_tls_helper.prepare_socket_for_tls_handshake(sock)

--- a/sslyze/server_setting.py
+++ b/sslyze/server_setting.py
@@ -173,6 +173,8 @@ class ServerNetworkConfiguration:
         xmpp_to_hostname: The hostname to set within the `to` attribute of the XMPP stream. If not supplied, the
             server's hostname will be used. Should only be set if the supplied `tls_opportunistic_encryption` is an
             XMPP protocol.
+        smtp_ehlo_hostname: The hostname to set in the SMTP EHLO. If not supplied, the default of "sslyze.scan"
+            will be used. Should only be set if the supplied `tls_opportunistic_encryption` is SMTP.
         network_timeout: The timeout (in seconds) to be used when attempting to establish a connection to the
             server.
         network_max_retries: The number of retries SSLyze will perform when attempting to establish a connection
@@ -184,6 +186,7 @@ class ServerNetworkConfiguration:
     tls_client_auth_credentials: Optional[ClientAuthenticationCredentials] = None
 
     xmpp_to_hostname: Optional[str] = None
+    smtp_ehlo_hostname: str = "sslyze.scan"
 
     network_timeout: int = 5
     network_max_retries: int = 3

--- a/sslyze/server_setting.py
+++ b/sslyze/server_setting.py
@@ -163,7 +163,7 @@ class ServerNetworkConfiguration:
 
     Attributes:
         tls_server_name_indication: The hostname to set within the Server Name Indication TLS extension.
-        tls_wrapped_protocol: The protocol wrapped in TLS that the server expects. It allows SSLyze to figure out
+        tls_opportunistic_encryption: The protocol wrapped in TLS that the server expects. It allows SSLyze to figure out
             how to establish a (Start)TLS connection to the server and what kind of "hello" message
             (SMTP, XMPP, etc.) to send to the server after the handshake was completed. If not supplied, standard
             TLS will be used.
@@ -171,7 +171,7 @@ class ServerNetworkConfiguration:
             with the server. If not supplied, SSLyze will attempt to connect to the server without performing
             client authentication.
         xmpp_to_hostname: The hostname to set within the `to` attribute of the XMPP stream. If not supplied, the
-            server's hostname will be used. Should only be set if the supplied `tls_wrapped_protocol` is an
+            server's hostname will be used. Should only be set if the supplied `tls_opportunistic_encryption` is an
             XMPP protocol.
         network_timeout: The timeout (in seconds) to be used when attempting to establish a connection to the
             server.


### PR DESCRIPTION
Some servers require that the SMTP EHLO hostname matches the reverse of the connecting client. This change allows Python clients to do that.

Did consider whether this was better placed in `ScanCommandsExtraArguments`, but I kept it simple and followed the flow of `xmpp_to`.

Also all includes s small doc fix: tls_wrapped_protocol->tls_opportunistic_encryption.