### PR TITLE
Support method extract_dns_subject_alternative_names

### DIFF
--- a/sslyze/plugins/certificate_info/_certificate_utils.py
+++ b/sslyze/plugins/certificate_info/_certificate_utils.py
@@ -47,6 +47,11 @@ def parse_subject_alternative_name_extension(certificate: Certificate) -> Subjec
     return SubjectAlternativeNameExtension(dns_names=dns_names, ip_addresses=ip_addresses)
 
 
+def extract_dns_subject_alternative_names(certificate: Certificate) -> List[str]:
+    san_extension = parse_subject_alternative_name_extension(certificate)
+    return san_extension.dns_names
+
+
 def get_common_names(name_field: Name) -> List[str]:
     return [cn.value for cn in name_field.get_attributes_for_oid(NameOID.COMMON_NAME)]  # type: ignore
 


### PR DESCRIPTION
### Reintroduce extract_dns_subject_alternative_names Method for Compatibility with Legacy Systems

This PR reinstates the `extract_dns_subject_alternative_names` method, which was part of the library up to version 5.0.6 inclusive. The method was deprecated and subsequently removed in favor of `parse_subject_alternative_name_extension`, but with this PR it be added back, however it will be using the existing code of `parse_subject_alternative_name_extension` instead of the deprecated method contents in order to benefit from better handling of Subject Alternative Names (SAN) in X.509 certificates. Reintroducing this method, will allow to support legacy systems that still depend on the `extract_dns_subject_alternative_names` method and will ease upgrade of the `sslyze` and dependencies, e.g. `cryptography` for more enhanced and robust security.

### Changes Introduced
Add new method `extract_dns_subject_alternative_names` that shares name with deprecated method and utilizes functionality of `parse_subject_alternative_name_extension` to ensure consistency and maintainability.
Method `extract_dns_subject_alternative_names` calls `parse_subject_alternative_name_extension` and extracts only DNS names, ensuring it functions similarly to the original method but aligns with the new code design.

```python
def extract_dns_subject_alternative_names(certificate: Certificate) -> List[str]:
    san_extension = parse_subject_alternative_name_extension(certificate)
    return san_extension.dns_names
```
