### PR TITLE
Refactoring of the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 /tests
 /docs
 /.github
+/.git


### PR DESCRIPTION
This PR will change up the Dockerfile a bit. The most important changes can be summarized as:
* Bump Python version 3.9 -> 3.12
* Add ability to specify Python version as build argument
* Use a 2-stage-build with virtual environment
  * Build in stage 0
  * Execute in stage 1
* Do not call setup.py anymore, instead use pip install
* Remove installation of sudo which seems to do nothing
* Add .git folder to .dockerignore

Considering that Python 3.9 is EOL next year's October I changed the default Python version to 3.12. Another version can simply be set when building with the "_--build-arg_" parameter like "_--build-arg PYTHON_VERSION='3.11'_" to use Python 3.11.
The usage of the venv and adding it to PATH eliminates the need to call sslyze with "_python -m sslyze_" and lets you call it directly with just "_sslyze_". 