### PR TITLE
Handle certificate unknown error

### DIFF
--- a/sslyze/connection_helpers/tls_connection.py
+++ b/sslyze/connection_helpers/tls_connection.py
@@ -127,6 +127,7 @@ _HANDSHAKE_REJECTED_TLS_ERRORS = {
     # enabled in the client; for example client only supports EC cipher suites but server returned an RSA certificate
     "wrong certificate type": "Server returned wrong certificate type",
     "invalid encoding": "TLS error: Invalid encoding",
+    "certificate unknown": "TLS alert: certificate unknown"
 }
 
 


### PR DESCRIPTION
Sometimes OpenSSL would throw a certificate unknown error that was not caught by SSLyze causing an uncaught exception to be thrown when scanning a host that sent a certificate that couldn't be read. 