### PR TITLE
Make sensitivity of is_vulnerable_to_client_renegotiation_dos configurable

### DIFF
--- a/sslyze/__init__.py
+++ b/sslyze/__init__.py
@@ -22,6 +22,7 @@ from sslyze.server_connectivity import (
 # Classes for setting up scan commands and extra arguments
 from sslyze.plugins.scan_commands import ScanCommand
 from sslyze.plugins.certificate_info.implementation import CertificateInfoExtraArgument
+from sslyze.plugins.session_renegotiation_plugin import SessionRenegotiationExtraArgument
 
 # Classes for scanning the servers
 from sslyze.scanner.models import (

--- a/sslyze/plugins/session_renegotiation_plugin.py
+++ b/sslyze/plugins/session_renegotiation_plugin.py
@@ -40,15 +40,18 @@ class SessionRenegotiationScanResult(ScanCommandResult):
     Attributes:
         accepts_client_renegotiation: True if the server honors client-initiated renegotiation attempts.
         supports_secure_renegotiation: True if the server supports secure renegotiation.
+        client_renegotiations_success_count: the number of successful client-initiated renegotiation attempts.
     """
 
     supports_secure_renegotiation: bool
     is_vulnerable_to_client_renegotiation_dos: bool
+    client_renegotiations_success_count: int
 
 
 class SessionRenegotiationScanResultAsJson(BaseModelWithOrmModeAndForbid):
     supports_secure_renegotiation: bool
     is_vulnerable_to_client_renegotiation_dos: bool
+    client_renegotiations_success_count: int
 
 
 class SessionRenegotiationScanAttemptAsJson(ScanCommandAttemptAsJson):
@@ -56,7 +59,7 @@ class SessionRenegotiationScanAttemptAsJson(ScanCommandAttemptAsJson):
 
 
 class _ScanJobResultEnum(Enum):
-    IS_VULNERABLE_TO_CLIENT_RENEG_DOS = 1
+    CLIENT_RENEG_RESULT = 1
     SUPPORTS_SECURE_RENEG = 2
 
 
@@ -87,7 +90,9 @@ class _SessionRenegotiationCliConnector(ScanCommandCliConnector[SessionRenegotia
         return result_txt
 
 
-class SessionRenegotiationImplementation(ScanCommandImplementation[SessionRenegotiationScanResult, None]):
+class SessionRenegotiationImplementation(
+    ScanCommandImplementation[SessionRenegotiationScanResult, SessionRenegotiationExtraArgument]
+):
     """Test a server for insecure TLS renegotiation and client-initiated renegotiation."""
 
     cli_connector_cls = _SessionRenegotiationCliConnector
@@ -118,11 +123,13 @@ class SessionRenegotiationImplementation(ScanCommandImplementation[SessionRenego
             result_enum, value = job.get_result()
             results_dict[result_enum] = value
 
+        is_vulnerable_to_client_renegotiation_dos, client_renegotiations_success_count = results_dict[
+            _ScanJobResultEnum.CLIENT_RENEG_RESULT
+        ]
         return SessionRenegotiationScanResult(
-            is_vulnerable_to_client_renegotiation_dos=results_dict[
-                _ScanJobResultEnum.IS_VULNERABLE_TO_CLIENT_RENEG_DOS
-            ],
+            is_vulnerable_to_client_renegotiation_dos=is_vulnerable_to_client_renegotiation_dos,
             supports_secure_renegotiation=results_dict[_ScanJobResultEnum.SUPPORTS_SECURE_RENEG],
+            client_renegotiations_success_count=client_renegotiations_success_count,
         )
 
 
@@ -163,9 +170,10 @@ def _test_secure_renegotiation(server_info: ServerConnectivityInfo) -> Tuple[_Sc
 
 def _test_client_renegotiation(
     server_info: ServerConnectivityInfo, client_renegotiation_attempts: int
-) -> Tuple[_ScanJobResultEnum, bool]:
+) -> Tuple[_ScanJobResultEnum, Tuple[bool, int]]:
     """Check whether the server honors session renegotiation requests."""
     # Try with TLS 1.2 even if the server supports TLS 1.3 or higher as there is no reneg with TLS 1.3
+    client_renegotiations_success_count = 0
     if server_info.tls_probing_result.highest_tls_version_supported.value >= TlsVersionEnum.TLS_1_3.value:
         tls_version_to_use = TlsVersionEnum.TLS_1_2
         downgraded_from_tls_1_3 = True
@@ -198,6 +206,7 @@ def _test_client_renegotiation(
             # https://github.com/nabla-c0d3/sslyze/issues/473
             for i in range(client_renegotiation_attempts):
                 ssl_connection.ssl_client.do_renegotiate()
+                client_renegotiations_success_count += 1
             accepts_client_renegotiation = True
 
         # Errors caused by a server rejecting the renegotiation
@@ -246,4 +255,4 @@ def _test_client_renegotiation(
     finally:
         ssl_connection.close()
 
-    return _ScanJobResultEnum.IS_VULNERABLE_TO_CLIENT_RENEG_DOS, accepts_client_renegotiation
+    return _ScanJobResultEnum.CLIENT_RENEG_RESULT, (accepts_client_renegotiation, client_renegotiations_success_count)

--- a/sslyze/scanner/models.py
+++ b/sslyze/scanner/models.py
@@ -18,7 +18,10 @@ from sslyze.plugins.openssl_ccs_injection_plugin import OpenSslCcsInjectionScanR
 from sslyze.plugins.openssl_cipher_suites.implementation import CipherSuitesScanResult
 from sslyze.plugins.robot.implementation import RobotScanResult
 from sslyze.plugins.scan_commands import ScanCommand, ScanCommandsRepository
-from sslyze.plugins.session_renegotiation_plugin import SessionRenegotiationScanResult
+from sslyze.plugins.session_renegotiation_plugin import (
+    SessionRenegotiationScanResult,
+    SessionRenegotiationExtraArgument,
+)
 from sslyze.plugins.session_resumption.implementation import (
     SessionResumptionSupportScanResult,
     SessionResumptionSupportExtraArgument,
@@ -33,6 +36,7 @@ class ScanCommandsExtraArguments:
     # Field is present if extra arguments were provided for the corresponding scan command
     certificate_info: Optional[CertificateInfoExtraArgument] = None
     session_resumption: Optional[SessionResumptionSupportExtraArgument] = None
+    session_renegotiation: Optional[SessionRenegotiationExtraArgument] = None
 
 
 @dataclass(frozen=True)

--- a/tests/json_tests/sslyze_output.json
+++ b/tests/json_tests/sslyze_output.json
@@ -8232,7 +8232,8 @@
           "error_trace": null,
           "result": {
             "supports_secure_renegotiation": true,
-            "is_vulnerable_to_client_renegotiation_dos": false
+            "is_vulnerable_to_client_renegotiation_dos": false,
+            "client_renegotiations_success_count": 0
           }
         },
         "session_resumption": {
@@ -17403,7 +17404,8 @@
           "error_trace": null,
           "result": {
             "supports_secure_renegotiation": true,
-            "is_vulnerable_to_client_renegotiation_dos": false
+            "is_vulnerable_to_client_renegotiation_dos": false,
+            "client_renegotiations_success_count": 0
           }
         },
         "session_resumption": {


### PR DESCRIPTION
Trying renegotiation multiple times to find mitigations makes sense. However, it is quite rare for servers to allow 1 but not too many renegotiations. For my use, I want to [test compliance with requirements](https://github.com/internetstandards/Internet.nl/issues/1483) that do not allow it at all. Therefore, I'd like it to be configurable.