### PR TITLE
Load CA bundle as bytes, not text

### DIFF
--- a/sslyze/plugins/certificate_info/trust_stores/trust_store.py
+++ b/sslyze/plugins/certificate_info/trust_stores/trust_store.py
@@ -52,7 +52,7 @@ class TrustStore:
         self.version = version
         self.ev_oids = ev_oids
 
-        self._x509_store = Store(load_pem_x509_certificates(self.path.read_text().encode("ascii")))
+        self._x509_store = Store(load_pem_x509_certificates(self.path.read_bytes()))
 
     def is_certificate_extended_validation(self, certificate: Certificate) -> bool:
         """Is the supplied server certificate EV?"""


### PR DESCRIPTION
A CA bundle may contain non-ASCII characters (e.g., CA distinguished names may include accents). When we try to encode these into bytes, the choise of the "ascii" codec causes a UnicodeError to be thrown.

Since we don't actaully want to do anythign with the CA bundle other than pass it to cryptograhpy, just load it as bytes in the first place.

Fixes: https://github.com/nabla-c0d3/sslyze/issues/670