### PR TITLE
bump cryptography version as there are known vulnerabilities in cryptography <43.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     # Dependencies
     install_requires=[
         "nassl>=5.1,<6",
-        "cryptography>42,<43",
+        "cryptography>43,<44",
         "tls-parser>=2,<3",
         "pydantic>=2.2,<2.7",
     ],


### PR DESCRIPTION
Cryptography <43 uses a version of `openssl` that is vulnerable to http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-6119 .
In version 43.0.1 they have updated to use of `OpenSSL >= 3.3.2`, fixing the issue