### PR TITLE
Unpin cryptography, and set minimum version to 44.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,14 @@ setup(
     # Dependencies
     install_requires=[
         "nassl>=5.3,<6",
-        "cryptography>=43,<45",
+        # cryptography doesn't use SemVer (they use browser versioning), and
+        # considers its declared API to be stable, even across major version
+        # changes. There may be breaking changes to address security issues,
+        # which has usually meant dropping support for old cryptographic
+        # primitives and protocols:
+        #
+        # https://cryptography.io/en/latest/api-stability/
+        "cryptography>=44.0.1",
         "tls-parser>=2,<3",
         "pydantic>=2.3,<3",
     ],


### PR DESCRIPTION
The Cryptography library doesn't follow SemVer for its versioning. Instead, it increments its major version any time it adds a new feature: https://cryptography.io/en/latest/api-stability/

Due to their versioning policy, and because their updates often address security issues in older versions, I would like to propose removing the maximum version constraint for cryptography.

If someone runs into a problem due to a removed symbol (eg, if something completely removes support for an old SSL/TLS version or removes a cipher suite that sslyze directly references), then they can be advised to try downgrading cryptography to an older version (at the risk of having certain vulns included).

This PR also addresses https://osv.dev/vulnerability/GHSA-79v4-65xg-pq4g by updating the minimum version of cryptography.