### PR TITLE
Add secp256r1 to mozzila tls profile

### DIFF
--- a/sslyze/mozilla_tls_profile/5.7.json
+++ b/sslyze/mozilla_tls_profile/5.7.json
@@ -3,7 +3,7 @@
     "href": "https://ssl-config.mozilla.org/guidelines/5.7.json",
     "configurations": {
         "modern": {
-            "certificate_curves": ["prime256v1", "secp384r1"],
+            "certificate_curves": ["prime256v1", "secp256r1", "secp384r1"],
             "certificate_signatures": ["ecdsa-with-SHA256", "ecdsa-with-SHA384", "ecdsa-with-SHA512"],
             "certificate_types": ["ecdsa"],
             "ciphers": {
@@ -26,11 +26,11 @@
             "recommended_certificate_lifespan": 90,
             "rsa_key_size": null,
             "server_preferred_order": false,
-            "tls_curves": ["X25519", "prime256v1", "secp384r1"],
+            "tls_curves": ["X25519", "prime256v1", "secp256r1", "secp384r1"],
             "tls_versions": ["TLSv1.3"]
         },
         "intermediate": {
-            "certificate_curves": ["prime256v1", "secp384r1"],
+            "certificate_curves": ["prime256v1", "secp256r1", "secp384r1"],
             "certificate_signatures": ["sha256WithRSAEncryption", "ecdsa-with-SHA256", "ecdsa-with-SHA384", "ecdsa-with-SHA512"],
             "certificate_types": ["ecdsa", "rsa"],
             "ciphers": {
@@ -87,11 +87,11 @@
             "recommended_certificate_lifespan": 90,
             "rsa_key_size": 2048,
             "server_preferred_order": false,
-            "tls_curves": ["X25519", "prime256v1", "secp384r1"],
+            "tls_curves": ["X25519", "prime256v1", "secp256r1", "secp384r1"],
             "tls_versions": ["TLSv1.2", "TLSv1.3"]
         },
         "old": {
-            "certificate_curves": ["prime256v1", "secp384r1"],
+            "certificate_curves": ["prime256v1", "secp256r1", "secp384r1"],
             "certificate_signatures": ["sha256WithRSAEncryption"],
             "certificate_types": ["rsa"],
             "ciphers": {
@@ -202,7 +202,7 @@
             "recommended_certificate_lifespan": 90,
             "rsa_key_size": 2048,
             "server_preferred_order": true,
-            "tls_curves": ["X25519", "prime256v1", "secp384r1"],
+            "tls_curves": ["X25519", "prime256v1", "secp256r1", "secp384r1"],
             "tls_versions": ["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]
         }
     }


### PR DESCRIPTION
In this pull request I add the second name of the curve prime256v1: "secp256r1". This is the same curve but with a different name, see: https://crypto.stackexchange.com/questions/33052/is-there-any-difference-between-nist-and-secp-curves-in-terms-of-their-algorithm.

This commit fix an inconsistent error message, here is the output of sslyze for "www.yahoo.com":
![image](https://github.com/user-attachments/assets/60b8a9ac-b9c5-456b-8d6d-82ae8f0d0266)

And with the fix I propose in this PR, here is the output:
![image](https://github.com/user-attachments/assets/1b64c320-cd34-471a-9207-4bfd99c9bead)
