### PR TITLE
Ignore incidental OpenSSLError in cert scan, ref #690

### DIFF
--- a/sslyze/plugins/certificate_info/implementation.py
+++ b/sslyze/plugins/certificate_info/implementation.py
@@ -122,7 +122,7 @@ class CertificateInfoImplementation(ScanCommandImplementation[CertificateInfoSca
                 received_chain_as_pem, ocsp_response, custom_ca_file, was_sni_used = completed_job.get_result()
                 assert received_chain_as_pem, "Should never happen as we always retrieve a certificate chain"
 
-            except TlsHandshakeFailed as exc:
+            except (TlsHandshakeFailed, nassl._nassl.OpenSSLError) as exc:
                 # Can happen when trying to connect with specific cipher suites (such as RSA or non-RSA)
                 # or when connectivity is bad
                 all_handshake_failed_exceptions.append(exc)


### PR DESCRIPTION
After 5bba4e3 / #690, it is no longer possible to run the certificate scan on servers that do not allow connections without SNI, such as internet.nl. This failed connection should just be ignored.

```
         File ".../sslyze/scanner/_mass_scanner.py", line 279, in _generate_result_for_completed_server_scan
    scan_cmd_result = plugin_implementation_cls.result_for_completed_scan_jobs(
         File ".../sslyze/plugins/certificate_info/implementation.py", line 122, in result_for_completed_scan_jobs
    received_chain_as_pem, ocsp_response, custom_ca_file, was_sni_used = completed_job.get_result()
         File ".../sslyze/plugins/plugin_base.py", line 60, in get_result
    raise self._exception
         File ".../sslyze/scanner/_jobs_worker_thread.py", line 59, in run
    return_value = job_to_complete.function_to_call(*job_to_complete.function_arguments)
         File ".../sslyze/plugins/certificate_info/_get_cert_chain.py", line 31, in get_certificate_chain
    ssl_connection.connect()
         File ".../sslyze/connection_helpers/tls_connection.py", line 301, in connect
    self.ssl_client.do_handshake()
         File ".../nassl/ssl_client.py", line 204, in do_handshake
    self._ssl.do_handshake()
       nassl._nassl.OpenSSLError: error:14094458:SSL routines:ssl3_read_bytes:tlsv1 unrecognized name
```

This PR catches `OpenSSLError` in the same way as `TLSHandshakeFailed`, i.e. ignoring it unless all connections fail. This is a broad exception, so there may be side effects I am unaware of.