### PR TITLE
Allow cryptography>=43,<47 to allow fix for CVE-2026-26007

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     # Dependencies
     install_requires=[
         "nassl>=5.4,<6",
-        "cryptography>=43,<45",
+        "cryptography>=43,<47",
         "tls-parser>=2,<3",
         "pydantic>=2.3,<3",
     ],


### PR DESCRIPTION
This allows cryptography>=43,<47 to allow fix for CVE-2026-26007

I've run the tests with cryptography==46.0.5 and whilst it does emit a few more warnings related to X.509 serial numbers not being positive integers, I don't believe this is much different to the similar warning already emitted. All other tests passed.

https://github.com/nabla-c0d3/sslyze/issues/714#issue-4035003418