### PR TITLE
Allow cryptography>=43,<51 to allow fix for reported vulnerabilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     # Dependencies
     install_requires=[
         "nassl>=5.4,<6",
-        "cryptography>=43,<47",
+        "cryptography>=43,<51",
         "tls-parser>=2,<3",
         "pydantic>=2.3,<3",
     ],


### PR DESCRIPTION
This allows for cryptography>=43,<51 to allow fixes for CVE-2026-69247, CVE-2026-69248, CVE-2026-69249

I ran the tests and got the same passes and warnings using both cryptography versions 46.0.7 and 50.0.0 (130 passed, 49 skipped, 7 warnings).

#726