### PR TITLE
Add a signature_algorithms scan command (#685)

### DIFF
--- a/docs/available-scan-commands.rst
+++ b/docs/available-scan-commands.rst
@@ -180,3 +180,15 @@ Result class
 ============
 
 .. autoclass:: EmsExtensionScanResult
+
+
+Signature Algorithms
+********************
+
+**ScanCommand.SIGNATURE_ALGORITHMS**: Test a server for the signature algorithms it accepts for the TLS handshake.
+
+Result class
+============
+
+.. autoclass:: SignatureAlgorithmsScanResult
+.. autoclass:: SignatureAlgorithm

--- a/sslyze/__init__.py
+++ b/sslyze/__init__.py
@@ -86,5 +86,6 @@ from sslyze.plugins.openssl_ccs_injection_plugin import OpenSslCcsInjectionScanR
 from sslyze.plugins.session_renegotiation_plugin import SessionRenegotiationScanResult
 from sslyze.plugins.elliptic_curves_plugin import SupportedEllipticCurvesScanResult, EllipticCurve
 from sslyze.plugins.ems_extension_plugin import EmsExtensionScanResult
+from sslyze.plugins.signature_algorithms_plugin import SignatureAlgorithmsScanResult, SignatureAlgorithm
 
 from sslyze.json.json_output import SslyzeOutputAsJson, ServerScanResultAsJson

--- a/sslyze/json/json_output.py
+++ b/sslyze/json/json_output.py
@@ -36,6 +36,7 @@ from sslyze.plugins.session_resumption.json_output import (
     SessionResumptionSupportExtraArgumentAsJson,
     SessionResumptionSupportScanAttemptAsJson,
 )
+from sslyze.plugins.signature_algorithms_plugin import SignatureAlgorithmsScanAttemptAsJson
 from sslyze.scanner.models import AllScanCommandsAttempts
 from sslyze.server_setting import ConnectionTypeEnum, ServerNetworkLocation
 
@@ -66,6 +67,7 @@ class AllScanCommandsAttemptsAsJson(BaseModelWithOrmModeAndForbid):
     http_headers: HttpHeadersScanAttemptAsJson
     tls_extended_master_secret: EmsExtensionScanAttemptAsJson
     pq_key_exchange: PqKeyExchangeScanAttemptAsJson
+    signature_algorithms: SignatureAlgorithmsScanAttemptAsJson
 
     @model_validator(mode="before")
     @classmethod

--- a/sslyze/plugins/scan_commands.py
+++ b/sslyze/plugins/scan_commands.py
@@ -22,6 +22,7 @@ from sslyze.plugins.pq_key_exchange_plugin import PqKeyExchangeImplementation
 from sslyze.plugins.robot.implementation import RobotImplementation
 from sslyze.plugins.session_renegotiation_plugin import SessionRenegotiationImplementation
 from sslyze.plugins.session_resumption.implementation import SessionResumptionSupportImplementation
+from sslyze.plugins.signature_algorithms_plugin import SignatureAlgorithmsImplementation
 
 if TYPE_CHECKING:
     from sslyze.plugins.plugin_base import ScanCommandImplementation
@@ -47,6 +48,7 @@ class ScanCommand(str, Enum):
     ELLIPTIC_CURVES = "elliptic_curves"
     TLS_EXTENDED_MASTER_SECRET = "tls_extended_master_secret"
     PQ_KEY_EXCHANGE = "pq_key_exchange"
+    SIGNATURE_ALGORITHMS = "signature_algorithms"
 
 
 class ScanCommandsRepository:
@@ -79,4 +81,5 @@ _IMPLEMENTATION_CLASSES: dict[ScanCommand, type["ScanCommandImplementation"]] = 
     ScanCommand.ELLIPTIC_CURVES: SupportedEllipticCurvesImplementation,
     ScanCommand.TLS_EXTENDED_MASTER_SECRET: EmsExtensionImplementation,
     ScanCommand.PQ_KEY_EXCHANGE: PqKeyExchangeImplementation,
+    ScanCommand.SIGNATURE_ALGORITHMS: SignatureAlgorithmsImplementation,
 }

--- a/sslyze/plugins/signature_algorithms_plugin.py
+++ b/sslyze/plugins/signature_algorithms_plugin.py
@@ -1,0 +1,207 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from nassl.base_ssl_client import ClientCertificateRequested
+from nassl.ephemeral_key_info import OpenSslEvpPkeyEnum
+from nassl.errors import OpenSSLError
+from nassl.openssl_1_1_1.ssl_client import OpenSslDigestNidEnum, SslClient_OpenSSL_1_1_1
+
+from sslyze.connection_helpers.tls_connection import OpenSslVersionEnum
+from sslyze.errors import ServerRejectedTlsHandshake, TlsHandshakeTimedOut
+from sslyze.json.pydantic_utils import BaseModelWithOrmModeAndForbid
+from sslyze.json.scan_attempt_json import ScanCommandAttemptAsJson
+from sslyze.plugins.plugin_base import (
+    ScanCommandCliConnector,
+    ScanCommandExtraArgument,
+    ScanCommandImplementation,
+    ScanCommandResult,
+    ScanCommandWrongUsageError,
+    ScanJob,
+    ScanJobResult,
+)
+from sslyze.server_connectivity import ServerConnectivityInfo, TlsVersionEnum, enable_ecdh_cipher_suites
+
+
+class SignatureAlgorithm(str, Enum):
+    """A signature algorithm that a client can offer in the TLS signature_algorithms extension.
+
+    The names follow the TLS 1.3 SignatureScheme registry (RFC 8446) where they map cleanly; the
+    generic ecdsa_* names are used because SSL_set1_sigalgs() only lets us pin the digest and the key
+    type, not the curve.
+    """
+
+    RSA_PKCS1_SHA1 = "rsa_pkcs1_sha1"
+    RSA_PKCS1_SHA224 = "rsa_pkcs1_sha224"
+    RSA_PKCS1_SHA256 = "rsa_pkcs1_sha256"
+    RSA_PKCS1_SHA384 = "rsa_pkcs1_sha384"
+    RSA_PKCS1_SHA512 = "rsa_pkcs1_sha512"
+    ECDSA_SHA1 = "ecdsa_sha1"
+    ECDSA_SHA224 = "ecdsa_sha224"
+    ECDSA_SHA256 = "ecdsa_sha256"
+    ECDSA_SHA384 = "ecdsa_sha384"
+    ECDSA_SHA512 = "ecdsa_sha512"
+    RSA_PSS_RSAE_SHA256 = "rsa_pss_rsae_sha256"
+    RSA_PSS_RSAE_SHA384 = "rsa_pss_rsae_sha384"
+    RSA_PSS_RSAE_SHA512 = "rsa_pss_rsae_sha512"
+
+
+# Each signature algorithm maps to the (digest, public key) NID pair that SSL_set1_sigalgs() expects
+_SIGNATURE_ALGORITHM_TO_NASSL: dict[SignatureAlgorithm, tuple[OpenSslDigestNidEnum, OpenSslEvpPkeyEnum]] = {
+    SignatureAlgorithm.RSA_PKCS1_SHA1: (OpenSslDigestNidEnum.SHA1, OpenSslEvpPkeyEnum.RSA),
+    SignatureAlgorithm.RSA_PKCS1_SHA224: (OpenSslDigestNidEnum.SHA224, OpenSslEvpPkeyEnum.RSA),
+    SignatureAlgorithm.RSA_PKCS1_SHA256: (OpenSslDigestNidEnum.SHA256, OpenSslEvpPkeyEnum.RSA),
+    SignatureAlgorithm.RSA_PKCS1_SHA384: (OpenSslDigestNidEnum.SHA384, OpenSslEvpPkeyEnum.RSA),
+    SignatureAlgorithm.RSA_PKCS1_SHA512: (OpenSslDigestNidEnum.SHA512, OpenSslEvpPkeyEnum.RSA),
+    SignatureAlgorithm.ECDSA_SHA1: (OpenSslDigestNidEnum.SHA1, OpenSslEvpPkeyEnum.EC),
+    SignatureAlgorithm.ECDSA_SHA224: (OpenSslDigestNidEnum.SHA224, OpenSslEvpPkeyEnum.EC),
+    SignatureAlgorithm.ECDSA_SHA256: (OpenSslDigestNidEnum.SHA256, OpenSslEvpPkeyEnum.EC),
+    SignatureAlgorithm.ECDSA_SHA384: (OpenSslDigestNidEnum.SHA384, OpenSslEvpPkeyEnum.EC),
+    SignatureAlgorithm.ECDSA_SHA512: (OpenSslDigestNidEnum.SHA512, OpenSslEvpPkeyEnum.EC),
+    SignatureAlgorithm.RSA_PSS_RSAE_SHA256: (OpenSslDigestNidEnum.SHA256, OpenSslEvpPkeyEnum.RSA_PSS),
+    SignatureAlgorithm.RSA_PSS_RSAE_SHA384: (OpenSslDigestNidEnum.SHA384, OpenSslEvpPkeyEnum.RSA_PSS),
+    SignatureAlgorithm.RSA_PSS_RSAE_SHA512: (OpenSslDigestNidEnum.SHA512, OpenSslEvpPkeyEnum.RSA_PSS),
+}
+
+
+@dataclass(frozen=True)
+class SignatureAlgorithmsScanResult(ScanCommandResult):
+    """The result of testing which signature algorithms a server accepts for the TLS handshake signature.
+
+    Attributes:
+        supported_signature_algorithms: The list of signature algorithms the server completed a handshake with.
+        rejected_signature_algorithms: The list of signature algorithms the server would not use.
+    """
+
+    supported_signature_algorithms: list[SignatureAlgorithm]
+    rejected_signature_algorithms: list[SignatureAlgorithm]
+
+    def __post_init__(self) -> None:
+        # Sort the algorithms by name
+        if self.supported_signature_algorithms:
+            self.supported_signature_algorithms.sort(key=lambda sig_alg: sig_alg.value)
+        if self.rejected_signature_algorithms:
+            self.rejected_signature_algorithms.sort(key=lambda sig_alg: sig_alg.value)
+
+
+class SignatureAlgorithmsScanResultAsJson(BaseModelWithOrmModeAndForbid):
+    supported_signature_algorithms: list[str]
+    rejected_signature_algorithms: list[str]
+
+
+assert SignatureAlgorithmsScanResult.__doc__
+SignatureAlgorithmsScanResultAsJson.__doc__ = SignatureAlgorithmsScanResult.__doc__
+
+
+class SignatureAlgorithmsScanAttemptAsJson(ScanCommandAttemptAsJson):
+    result: SignatureAlgorithmsScanResultAsJson | None
+
+
+class _SignatureAlgorithmsCliConnector(ScanCommandCliConnector[SignatureAlgorithmsScanResult, None]):
+    _cli_option = "signature_algorithms"
+    _cli_description = "Test a server for the signature algorithms it accepts for the TLS handshake."
+
+    @classmethod
+    def result_to_console_output(cls, result: SignatureAlgorithmsScanResult) -> list[str]:
+        result_as_txt = [cls._format_title("Signature Algorithms")]
+
+        supported = [sig_alg.value for sig_alg in result.supported_signature_algorithms]
+        rejected = [sig_alg.value for sig_alg in result.rejected_signature_algorithms]
+        if supported:
+            result_as_txt.append(cls._format_field("Supported signature algorithms:", ", ".join(supported)))
+        else:
+            result_as_txt.append(
+                cls._format_subtitle("The server did not accept any of the tested signature algorithms.")
+            )
+        result_as_txt.append(cls._format_field("Rejected signature algorithms:", ", ".join(rejected)))
+        return result_as_txt
+
+
+class SignatureAlgorithmsImplementation(ScanCommandImplementation[SignatureAlgorithmsScanResult, None]):
+    """Test a server for the signature algorithms it accepts for the TLS handshake."""
+
+    cli_connector_cls = _SignatureAlgorithmsCliConnector
+
+    @classmethod
+    def scan_jobs_for_scan_command(
+        cls, server_info: ServerConnectivityInfo, extra_arguments: ScanCommandExtraArgument | None = None
+    ) -> list[ScanJob]:
+        if extra_arguments:
+            raise ScanCommandWrongUsageError("This plugin does not take extra arguments")
+
+        return [
+            ScanJob(function_to_call=_test_signature_algorithm, function_arguments=[server_info, sig_alg])
+            for sig_alg in SignatureAlgorithm
+        ]
+
+    @classmethod
+    def result_for_completed_scan_jobs(
+        cls, server_info: ServerConnectivityInfo, scan_job_results: list[ScanJobResult]
+    ) -> SignatureAlgorithmsScanResult:
+        if len(scan_job_results) != len(SignatureAlgorithm):
+            raise RuntimeError(f"Unexpected number of scan jobs received: {scan_job_results}")
+
+        all_results = [scan_job.get_result() for scan_job in scan_job_results]
+        return SignatureAlgorithmsScanResult(
+            supported_signature_algorithms=[r.signature_algorithm for r in all_results if r.was_accepted_by_server],
+            rejected_signature_algorithms=[r.signature_algorithm for r in all_results if not r.was_accepted_by_server],
+        )
+
+
+@dataclass(frozen=True)
+class _SignatureAlgorithmResult:
+    signature_algorithm: SignatureAlgorithm
+    was_accepted_by_server: bool
+
+
+def _test_signature_algorithm(
+    server_info: ServerConnectivityInfo, signature_algorithm: SignatureAlgorithm
+) -> _SignatureAlgorithmResult:
+    tls_version = server_info.tls_probing_result.highest_tls_version_supported
+    ssl_connection = server_info.get_preconfigured_tls_connection(
+        override_tls_version=tls_version, openssl_version=OpenSslVersionEnum.OPENSSL_1_1_1
+    )
+    assert isinstance(ssl_connection.ssl_client, SslClient_OpenSSL_1_1_1), "Should never happen"
+
+    # A signature only shows up in the handshake if the key exchange is signed (TLS 1.3 always signs the
+    # CertificateVerify; for TLS 1.2 we force an (EC)DHE cipher suite so the server signs the key exchange).
+    if tls_version != TlsVersionEnum.TLS_1_3:
+        enable_ecdh_cipher_suites(tls_version, ssl_connection.ssl_client)
+
+    digest_nid, public_key_nid = _SIGNATURE_ALGORITHM_TO_NASSL[signature_algorithm]
+    ssl_connection.ssl_client.set_signature_algorithms([(digest_nid, public_key_nid)])
+
+    was_accepted_by_server = False
+    try:
+        ssl_connection.connect()
+        was_accepted_by_server = True
+
+    except ClientCertificateRequested:
+        # The server got far enough to ask for a client cert, so it accepted the signature algorithm
+        was_accepted_by_server = True
+
+    except (ServerRejectedTlsHandshake, TlsHandshakeTimedOut):
+        was_accepted_by_server = False
+
+    except OpenSSLError as e:
+        error_message = e.args[0]
+        # The client-side OpenSSL refuses to build a ClientHello when the single offered signature algorithm
+        # is not usable for the negotiated TLS version (for example an rsa_pkcs1 or SHA1 algorithm with TLS 1.3);
+        # some servers also just send a handshake_failure alert. Either way the algorithm is not usable here.
+        if (
+            "signature algorithm" in error_message
+            or "sigalg" in error_message
+            or "sig_alg" in error_message
+            or "no shared cipher" in error_message
+            or "sslv3 alert handshake failure" in error_message
+        ):
+            was_accepted_by_server = False
+        else:
+            raise
+
+    finally:
+        ssl_connection.close()
+
+    return _SignatureAlgorithmResult(
+        signature_algorithm=signature_algorithm,
+        was_accepted_by_server=was_accepted_by_server,
+    )

--- a/sslyze/scanner/models.py
+++ b/sslyze/scanner/models.py
@@ -25,6 +25,7 @@ from sslyze.plugins.session_resumption.implementation import (
     SessionResumptionSupportExtraArgument,
     SessionResumptionSupportScanResult,
 )
+from sslyze.plugins.signature_algorithms_plugin import SignatureAlgorithmsScanResult
 from sslyze.scanner.scan_command_attempt import ScanCommandAttempt
 from sslyze.server_connectivity import ServerTlsProbingResult
 from sslyze.server_setting import ServerNetworkLocation
@@ -139,6 +140,10 @@ class PqKeyExchangeScanAttempt(ScanCommandAttempt[PqKeyExchangeScanResult]):
     pass
 
 
+class SignatureAlgorithmsScanAttempt(ScanCommandAttempt[SignatureAlgorithmsScanResult]):
+    pass
+
+
 @dataclass(frozen=True)
 class AllScanCommandsAttempts:
     """The result of every scan command supported by SSLyze."""
@@ -162,6 +167,7 @@ class AllScanCommandsAttempts:
     http_headers: HttpHeadersScanAttempt
     tls_extended_master_secret: EmsExtensionScanAttempt
     pq_key_exchange: PqKeyExchangeScanAttempt
+    signature_algorithms: SignatureAlgorithmsScanAttempt
 
 
 _SCAN_CMD_FIELD_NAME_TO_CLS: dict[str, type[ScanCommandAttempt]] = {

--- a/tests/json_tests/sslyze_output.json
+++ b/tests/json_tests/sslyze_output.json
@@ -9203,6 +9203,44 @@
           "result": {
             "supports_ems_extension": true
           }
+        },
+        "signature_algorithms": {
+          "status": "COMPLETED",
+          "error_reason": null,
+          "error_trace": null,
+          "result": {
+            "supported_signature_algorithms": [
+              "ecdsa_sha256",
+              "rsa_pss_rsae_sha256",
+              "rsa_pss_rsae_sha384",
+              "rsa_pss_rsae_sha512"
+            ],
+            "rejected_signature_algorithms": [
+              "ecdsa_sha1",
+              "ecdsa_sha224",
+              "ecdsa_sha384",
+              "ecdsa_sha512",
+              "rsa_pkcs1_sha1",
+              "rsa_pkcs1_sha224",
+              "rsa_pkcs1_sha256",
+              "rsa_pkcs1_sha384",
+              "rsa_pkcs1_sha512"
+            ]
+          }
+        },
+        "pq_key_exchange": {
+          "status": "COMPLETED",
+          "error_reason": null,
+          "error_trace": null,
+          "result": {
+            "supported_pq_groups": [],
+            "rejected_pq_groups": [
+              "SecP256r1MLKEM768",
+              "SecP384r1MLKEM1024",
+              "X25519MLKEM768"
+            ],
+            "supports_pq_key_exchange": false
+          }
         }
       }
     },
@@ -17558,6 +17596,44 @@
           "error_trace": null,
           "result": {
             "supports_ems_extension": true
+          }
+        },
+        "signature_algorithms": {
+          "status": "COMPLETED",
+          "error_reason": null,
+          "error_trace": null,
+          "result": {
+            "supported_signature_algorithms": [
+              "ecdsa_sha256",
+              "rsa_pss_rsae_sha256",
+              "rsa_pss_rsae_sha384",
+              "rsa_pss_rsae_sha512"
+            ],
+            "rejected_signature_algorithms": [
+              "ecdsa_sha1",
+              "ecdsa_sha224",
+              "ecdsa_sha384",
+              "ecdsa_sha512",
+              "rsa_pkcs1_sha1",
+              "rsa_pkcs1_sha224",
+              "rsa_pkcs1_sha256",
+              "rsa_pkcs1_sha384",
+              "rsa_pkcs1_sha512"
+            ]
+          }
+        },
+        "pq_key_exchange": {
+          "status": "COMPLETED",
+          "error_reason": null,
+          "error_trace": null,
+          "result": {
+            "supported_pq_groups": [],
+            "rejected_pq_groups": [
+              "SecP256r1MLKEM768",
+              "SecP384r1MLKEM1024",
+              "X25519MLKEM768"
+            ],
+            "supports_pq_key_exchange": false
           }
         }
       }

--- a/tests/plugins_tests/test_signature_algorithms_plugin.py
+++ b/tests/plugins_tests/test_signature_algorithms_plugin.py
@@ -1,0 +1,92 @@
+from sslyze import ServerNetworkLocation
+from sslyze.plugins.signature_algorithms_plugin import (
+    SignatureAlgorithm,
+    SignatureAlgorithmsImplementation,
+    SignatureAlgorithmsScanResult,
+    SignatureAlgorithmsScanResultAsJson,
+)
+from tests.connectivity_utils import check_connectivity_to_server_and_return_info
+from tests.markers import can_only_run_on_linux_64
+from tests.openssl_server import ModernOpenSslServer
+
+
+class TestSignatureAlgorithmsPluginWithOnlineServer:
+    def test_supported_signature_algorithms(self) -> None:
+        # Given a server to scan
+        server_location = ServerNetworkLocation("www.cloudflare.com", 443)
+        server_info = check_connectivity_to_server_and_return_info(server_location)
+
+        # When scanning for supported signature algorithms, it succeeds
+        result: SignatureAlgorithmsScanResult = SignatureAlgorithmsImplementation.scan_server(server_info)
+
+        # And the result confirms that some algorithms are supported and some are not
+        assert result.supported_signature_algorithms
+        assert result.rejected_signature_algorithms
+
+        # And a CLI output can be generated
+        assert SignatureAlgorithmsImplementation.cli_connector_cls.result_to_console_output(result)
+
+        # And the result can be converted to JSON
+        result_as_json = SignatureAlgorithmsScanResultAsJson.model_validate(result).model_dump_json()
+        assert result_as_json
+
+
+class TestSignatureAlgorithmsResultSerialization:
+    def test_console_and_json_round_trip(self) -> None:
+        # Given a result built without any network connection
+        result = SignatureAlgorithmsScanResult(
+            supported_signature_algorithms=[
+                SignatureAlgorithm.RSA_PSS_RSAE_SHA256,
+                SignatureAlgorithm.RSA_PKCS1_SHA256,
+            ],
+            rejected_signature_algorithms=[SignatureAlgorithm.ECDSA_SHA256],
+        )
+
+        # When generating the CLI output, it lists the algorithms
+        cli_output = SignatureAlgorithmsImplementation.cli_connector_cls.result_to_console_output(result)
+        assert cli_output
+        assert any(SignatureAlgorithm.RSA_PSS_RSAE_SHA256.value in line for line in cli_output)
+
+        # And the result can be serialized to JSON and keeps the algorithm names
+        result_as_json = SignatureAlgorithmsScanResultAsJson.model_validate(result).model_dump_json()
+        assert SignatureAlgorithm.RSA_PSS_RSAE_SHA256.value in result_as_json
+        assert SignatureAlgorithm.ECDSA_SHA256.value in result_as_json
+
+    def test_empty_result_console_output(self) -> None:
+        # Given a result where the server accepted nothing
+        result = SignatureAlgorithmsScanResult(
+            supported_signature_algorithms=[],
+            rejected_signature_algorithms=[SignatureAlgorithm.RSA_PKCS1_SHA1],
+        )
+
+        # When generating the CLI output, it still works and flags the absence
+        cli_output = SignatureAlgorithmsImplementation.cli_connector_cls.result_to_console_output(result)
+        assert cli_output
+        assert any("did not accept" in line for line in cli_output)
+
+
+@can_only_run_on_linux_64
+class TestSignatureAlgorithmsPluginWithLocalServer:
+    def test_supported_signature_algorithms(self) -> None:
+        # Given a local server with an RSA certificate
+        with ModernOpenSslServer() as server:
+            server_location = ServerNetworkLocation(
+                hostname=server.hostname, ip_address=server.ip_address, port=server.port
+            )
+            server_info = check_connectivity_to_server_and_return_info(server_location)
+
+            # When scanning the server for supported signature algorithms, it succeeds
+            result: SignatureAlgorithmsScanResult = SignatureAlgorithmsImplementation.scan_server(server_info)
+
+        # And an RSA-PSS algorithm was detected as supported (the server has an RSA certificate)
+        assert SignatureAlgorithm.RSA_PSS_RSAE_SHA256 in result.supported_signature_algorithms
+
+        # And no ECDSA algorithm was accepted since the server does not have an ECDSA certificate
+        ecdsa_algorithms = {
+            SignatureAlgorithm.ECDSA_SHA1,
+            SignatureAlgorithm.ECDSA_SHA224,
+            SignatureAlgorithm.ECDSA_SHA256,
+            SignatureAlgorithm.ECDSA_SHA384,
+            SignatureAlgorithm.ECDSA_SHA512,
+        }
+        assert not ecdsa_algorithms.intersection(result.supported_signature_algorithms)


### PR DESCRIPTION
Adds a `signature_algorithms` scan command that reports which TLS signature algorithms a server will actually use for the handshake, which is what #685 asked for.

It works like the elliptic curves plugin. For each candidate algorithm it pins a single (digest, key type) pair through the new nassl `set_signature_algorithms()` binding and tries to handshake, so a completed handshake means the server accepted that algorithm. TLS 1.3 always signs the CertificateVerify, and for TLS 1.2 the plugin forces an (EC)DHE cipher suite so the server signs the key exchange. When the client-side OpenSSL won't even build a ClientHello for a given algorithm (say rsa_pkcs1 or a SHA1 algorithm under TLS 1.3) that algorithm gets recorded as rejected instead of blowing up the scan. The candidate set covers RSA PKCS#1, ECDSA and RSA-PSS across SHA1/224/256/384/512, so it also surfaces servers still willing to sign with SHA1.

Registration follows how pq_key_exchange is wired: the scan command enum and repository, the scanner models, the JSON output model, and the top-level exports. I also filled in the pq_key_exchange and signature_algorithms entries that the JSON round-trip fixture (`tests/json_tests/sslyze_output.json`) was missing so that test parses again.

Tests mirror `test_elliptic_curves_plugin.py`: an online run against cloudflare, a local OpenSSL server run (RSA cert, so RSA-PSS shows up as supported and ECDSA does not), plus a couple of offline checks for the console and JSON serialization.

```
$ python -m pytest tests/plugins_tests/test_elliptic_curves_plugin.py tests/plugins_tests/test_signature_algorithms_plugin.py tests/json_tests/test_json_output.py
...........                                                              [100%]
11 passed in 2.78s
```

Targeted `dev` since that is where pq_key_exchange and the other 7.0 plugins live. `dev` pins `nassl>=7.0`, which is not on PyPI yet, so I built nassl 7.0 locally to run the suite (the commit right before the curve/group refactor, which still exports the `_OPENSSL_NID_TO_SECG_ANSI_X9_62` symbol `elliptic_curves_plugin` imports).
