### PR TITLE
Reconfigure stdout/stderr to UTF-8 before printing scan results

### DIFF
--- a/sslyze/__main__.py
+++ b/sslyze/__main__.py
@@ -23,6 +23,14 @@ from sslyze.mozilla_tls_profile.tls_config_checker import (
 
 
 def main() -> None:
+    # Scan results can include server-supplied text (e.g. a certificate subject) with
+    # characters outside the console's active code page. On Windows this is not UTF-8 by
+    # default, and the frozen executable ignores PYTHONIOENCODING/PYTHONUTF8, so printing
+    # such text can raise UnicodeEncodeError and crash the scan instead of reporting it.
+    for stream in (sys.stdout, sys.stderr):
+        if stream is not None and hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+
     # Parse the supplied command line
     date_scans_started = datetime.now(timezone.utc)
     sslyze_parser = CommandLineParser(__version__)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import io
 from pathlib import Path
 import sys
 from tempfile import NamedTemporaryFile
@@ -9,6 +10,42 @@ from sslyze import SslyzeOutputAsJson
 from sslyze.__main__ import main
 from sslyze.cli.command_line_parser import CommandLineParser, CommandLineParsingError
 from sslyze.mozilla_tls_profile.tls_config_checker import TlsConfigurationEnum
+
+
+class TestMainStdoutEncoding:
+    def test_main_reconfigures_stdout_and_stderr_to_utf8(self):
+        # Given stdout/stderr set up like a redirected console on a non-UTF-8 locale
+        # (this is what a frozen Windows executable's stdout looks like)
+        fake_stdout = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        fake_stderr = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+
+        # When running main(), even on a command line that fails argument parsing
+        # and never reaches a scan
+        with (
+            mock.patch.object(sys, "argv", ["sslyze"]),
+            mock.patch.object(sys, "stdout", fake_stdout),
+            mock.patch.object(sys, "stderr", fake_stderr),
+        ):
+            main()
+
+        # Then stdout/stderr were switched to UTF-8 with a non-crashing error handler
+        assert fake_stdout.encoding.lower() == "utf-8"
+        assert fake_stdout.errors == "backslashreplace"
+        assert fake_stderr.encoding.lower() == "utf-8"
+        assert fake_stderr.errors == "backslashreplace"
+
+    def test_printing_non_cp1252_text_does_not_crash_after_main(self):
+        # Given a stream that would raise UnicodeEncodeError for this text before the fix
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        server_supplied_text = "Certificate subject CN=测试.example is not trusted"
+        with pytest.raises(UnicodeEncodeError):
+            print(server_supplied_text, file=stream)
+
+        # When main() reconfigures a stream the same way it reconfigures sys.stdout/stderr
+        stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+        # Then printing the same server-supplied text no longer raises
+        print(server_supplied_text, file=stream)
 
 
 class TestMain:


### PR DESCRIPTION
Fixes #724.

Printing a non-cp1252 certificate subject to a stream opened with encoding="cp1252" raises UnicodeEncodeError. This adds the stdout/stderr reconfigure from the issue at the top of main(), before any output happens.

Added two tests in test_main.py covering the reconfigure and the print that used to crash. Ran test_main.py, tests/cli_tests, ruff, and mypy on the changed files.
